### PR TITLE
Fix SimulationObserver metric handling

### DIFF
--- a/observer.py
+++ b/observer.py
@@ -5,16 +5,34 @@ This class captures the agents' states, environment conditions, and any other re
 import csv
 import json
 
+
 class SimulationObserver:
+    """Collect and store metrics over a simulation run."""
+
     def __init__(self):
+        # ``metrics`` holds the functions used to compute each metric while
+        # ``data`` stores the collected values.  Previously both were mixed in
+        # ``data``, leading to type errors when collecting.
+        self.metrics = {}
         self.data = {}
-        
+
     def add_metric(self, metric_name, metric_function):
+        """Register a metric to be tracked.
+
+        Parameters
+        ----------
+        metric_name: str
+            Name of the metric to record.
+        metric_function: Callable[[Any, Any], Any]
+            Function that computes the metric given the agents and
+            environment.
+        """
+        self.metrics[metric_name] = metric_function
         self.data[metric_name] = []
-        self.data[metric_name].append(metric_function)
-        
-    def collect_data(self, agents, environment):
-        for metric_name, metric_function in self.data.items():
+
+    def collect_data(self, agents, environment=None):
+        """Collect the current value for each registered metric."""
+        for metric_name, metric_function in self.metrics.items():
             value = metric_function(agents, environment)
             self.data[metric_name].append(value)
             

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from observer import SimulationObserver
+
+
+def test_collects_metrics():
+    obs = SimulationObserver()
+    # metric returns number of agents
+    obs.add_metric("count", lambda agents, env: len(agents))
+    agents = [1, 2, 3]
+    obs.collect_data(agents, None)
+    assert obs.data["count"] == [3]


### PR DESCRIPTION
## Summary
- correct SimulationObserver to store metric functions separately from collected data
- add regression test for SimulationObserver metric collection

## Testing
- `pytest tests/test_observer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c346c06a08323945df06ff4a0c6f6