### PR TITLE
docs: fix repository URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Use our handy code snippets to integrate Neva into your Python projects, GitHub 
 
 ## Installation
 ```bash
-git clone https://github.com/yourdavletovb/neva.git
+git clone https://github.com/davletovb/neva.git
 cd neva
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
## Summary
- correct clone URL in README installation section

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c367cae088323ab2e6d3d7f7912f0