### PR TITLE
Add conversation quickstart and expand scheduler coverage

### DIFF
--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -13,3 +13,27 @@ def test_collects_metrics():
     agents = [1, 2, 3]
     obs.collect_data(agents, None)
     assert obs.data["count"] == [3]
+
+
+def test_export_to_csv(tmp_path):
+    obs = SimulationObserver()
+    obs.add_metric("turns", lambda agents, env: len(agents))
+    obs.collect_data(["agent"], None)
+
+    csv_path = tmp_path / "metrics.csv"
+    obs.export_to_csv(csv_path)
+
+    assert csv_path.read_text().strip() == "turns,1"
+
+
+def test_export_to_json(tmp_path):
+    obs = SimulationObserver()
+    obs.add_metric("messages", lambda agents, env: [agent for agent in agents])
+    obs.collect_data(["A", "B"], None)
+
+    json_path = tmp_path / "metrics.json"
+    obs.export_to_json(json_path)
+
+    import json
+
+    assert json.loads(json_path.read_text()) == {"messages": [["A", "B"]]}

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from models import AIAgent
+from schedulers import PriorityScheduler, RoundRobinScheduler
+
+
+class StubAgent(AIAgent):
+    def __init__(self, name: str):
+        super().__init__(name=name)
+
+    def respond(self, message: str) -> str:  # pragma: no cover - not used here.
+        return message
+
+
+def test_round_robin_scheduler_cycles_agents_in_order():
+    scheduler = RoundRobinScheduler()
+    agents = [StubAgent("A"), StubAgent("B"), StubAgent("C")]
+    for agent in agents:
+        scheduler.add(agent)
+
+    selected = [scheduler.get_next_agent() for _ in range(5)]
+    assert [agent.name for agent in selected] == ["A", "B", "C", "A", "B"]
+
+
+def test_priority_scheduler_picks_highest_priority_first():
+    scheduler = PriorityScheduler()
+    low = StubAgent("low")
+    high = StubAgent("high")
+
+    scheduler.add(low, priority=1)
+    scheduler.add(high, priority=5)
+
+    assert scheduler.get_next_agent() is high
+
+    # After the first call the highest priority agent is reinserted, so the
+    # queue still prioritises it even when more agents are added.
+    another_low = StubAgent("another_low")
+    scheduler.add(another_low, priority=2)
+    assert scheduler.get_next_agent() is high


### PR DESCRIPTION
## Summary
- refresh the README quickstart and usage examples with the unified AgentManager API and add developer setup guidance
- add a runnable quickstart_conversation example that stages a minimal two-agent simulation
- extend unit tests to cover manager communication, scheduler ordering, and observer exports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e880e6975083239dec760bb9934f26