### PR TITLE
Add built-in observer metrics and improve tooling fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ python examples/quickstart_conversation.py
 
 Each call to `environment.step()` advances the simulation by a single message so
 you can observe the emergent collaboration unfold in just a few lines of code.
+When the script finishes it prints a snapshot of the automatically collected
+metrics (turn counts, participation rates, dialogue length, tool usage, and
+lightweight sentiment/intent analysis) and writes them to
+`quickstart_metrics.json` for later inspection.
+
+### Observability & Experiment Tracking
+
+The :class:`observer.SimulationObserver` now registers a suite of metrics out of
+the box, removing the need to manually wire analytics into every experiment. It
+tracks turn counts, per-agent participation, response latencies, recent
+sentiment/intent, and tool-usage frequency. Metrics can be exported to CSV/JSON
+or logged to MLflow with `SimulationObserver.log_to_mlflow()` to integrate with
+your preferred dashboarding stack.
 
 ## Installation
 Clone the repository and install the required packages:
@@ -77,6 +90,11 @@ configuration steps:
 - **Optional heavyweight dependencies** – examples that rely on summarisation or
   translation tools use `bert-extractive-summarizer` and `googletrans`. Install
   them only when needed to keep the core installation lightweight.
+- **Graceful fallbacks** – the built-in tools surface actionable error messages
+  when optional packages such as `wikipedia`, `googletrans`, or
+  `bert-extractive-summarizer` are unavailable. You can provide lightweight
+  factories to `TranslatorTool` and `SummarizerTool` (or monkeypatch the
+  Wikipedia backend) to keep experiments fully offline.
 
 After installing dependencies run `pytest` to confirm the environment is ready
 for development.

--- a/examples/quickstart_conversation.py
+++ b/examples/quickstart_conversation.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from typing import List
 
+from pathlib import Path
+
 from environments import BasicEnvironment
 from memory import CompositeMemory, MemoryRecord, ShortTermMemory, SummaryMemory
 from models import AgentManager
@@ -97,6 +99,16 @@ def main() -> None:
     for step, message in enumerate(environment.run(6), start=1):
         print(f"Step {step}: {message}")
     print("=== Conversation End ===")
+
+    observer = scheduler.simulation_observer
+    snapshot = observer.latest_snapshot()
+    print("\n=== Observer Metrics (latest snapshot) ===")
+    for name, value in snapshot.items():
+        print(f"{name}: {value}")
+
+    export_path = Path("quickstart_metrics.json")
+    observer.export_to_json(export_path)
+    print(f"Metrics exported to {export_path.resolve()}")
 
 
 if __name__ == "__main__":

--- a/observer.py
+++ b/observer.py
@@ -1,47 +1,378 @@
-"""
-This class captures the agents' states, environment conditions, and any other relevant metrics at each step of the simulation.
-"""
+"""Utilities for collecting, aggregating, and exporting simulation metrics."""
+
+from __future__ import annotations
 
 import csv
 import json
+import logging
+from collections import Counter, defaultdict
+from datetime import datetime
+from functools import wraps
+from time import perf_counter
+from types import MethodType
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_len(sequence: Optional[Iterable[Any]]) -> int:
+    """Return ``len(sequence)`` while tolerating ``None`` or iterables."""
+
+    if sequence is None:
+        return 0
+    try:
+        return len(sequence)  # type: ignore[arg-type]
+    except TypeError:
+        return sum(1 for _ in sequence)
 
 
 class SimulationObserver:
-    """Collect and store metrics over a simulation run."""
+    """Collect and store metrics over a simulation run.
 
-    def __init__(self):
-        # ``metrics`` holds the functions used to compute each metric while
-        # ``data`` stores the collected values.  Previously both were mixed in
-        # ``data``, leading to type errors when collecting.
-        self.metrics = {}
-        self.data = {}
+    The observer exposes ready-to-use metrics for common conversational
+    analysis tasks while still allowing callers to register their own metrics.
+    Each call to :meth:`collect_data` stores a snapshot that can be exported to
+    CSV/JSON or logged directly to experiment-tracking dashboards (for example
+    MLflow).
+    """
 
-    def add_metric(self, metric_name, metric_function):
-        """Register a metric to be tracked.
+    def __init__(
+        self,
+        *,
+        enable_builtin_metrics: bool = True,
+        sentiment_positive_words: Optional[Iterable[str]] = None,
+        sentiment_negative_words: Optional[Iterable[str]] = None,
+    ) -> None:
+        # ``metrics`` holds callables used to compute each metric while ``data``
+        # stores the collected values.
+        self.metrics: Dict[str, Callable[..., Any]] = {}
+        self.data: Dict[str, List[Any]] = {}
 
-        Parameters
-        ----------
-        metric_name: str
-            Name of the metric to record.
-        metric_function: Callable[[Any, Any], Any]
-            Function that computes the metric given the agents and
-            environment.
+        # Internal state to support built-in metrics.
+        self._turn_count = 0
+        self._last_turn_timestamp: Optional[datetime] = None
+        self._latest_latency: Optional[float] = None
+        self._latencies: List[float] = []
+        self._participation = Counter()
+        self._tool_usage: MutableMapping[str, Counter] = defaultdict(Counter)
+        self._tool_usage_events: List[Dict[str, Any]] = []
+        self._wrapped_tools: Dict[int, Callable[..., Any]] = {}
+        self._latest_agent_name: Optional[str] = None
+        self._sentiment_positive_words = set(sentiment_positive_words or {
+            "achieve",
+            "awesome",
+            "collaborate",
+            "creative",
+            "excellent",
+            "great",
+            "progress",
+            "success",
+            "wonderful",
+        })
+        self._sentiment_negative_words = set(sentiment_negative_words or {
+            "angry",
+            "bad",
+            "conflict",
+            "difficult",
+            "fail",
+            "frustrated",
+            "issue",
+            "problem",
+            "struggle",
+        })
+        self._sentiment_warning_emitted = False
+
+        if enable_builtin_metrics:
+            self._register_builtin_metrics()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def add_metric(self, metric_name: str, metric_function: Callable[..., Any]) -> None:
+        """Register ``metric_function`` under ``metric_name``.
+
+        The callable can optionally accept a ``context`` keyword argument which
+        provides additional information (active agent, latency, tool usage,
+        etc.). Callables that do not declare ``context`` remain supported for
+        backwards compatibility.
         """
-        self.metrics[metric_name] = metric_function
-        self.data[metric_name] = []
 
-    def collect_data(self, agents, environment=None):
+        self.metrics[metric_name] = metric_function
+        self.data.setdefault(metric_name, [])
+
+    def collect_data(
+        self,
+        agents: Iterable[Any],
+        environment: Optional[Any] = None,
+        *,
+        active_agent: Optional[Any] = None,
+    ) -> None:
         """Collect the current value for each registered metric."""
+
+        agent_list = list(agents)
+        now = datetime.utcnow()
+        latency: Optional[float] = None
+        if self._last_turn_timestamp is not None:
+            latency_delta = now - self._last_turn_timestamp
+            latency = latency_delta.total_seconds()
+            self._latest_latency = latency
+            self._latencies.append(latency)
+        self._last_turn_timestamp = now
+
+        if active_agent is not None:
+            self._turn_count += 1
+            agent_name = getattr(active_agent, "name", str(active_agent))
+            self._latest_agent_name = agent_name
+            self._participation[agent_name] += 1
+        else:
+            self._latest_agent_name = None
+
+        context = {
+            "active_agent": active_agent,
+            "active_agent_name": self._latest_agent_name,
+            "agents": list(agent_list),
+            "environment": environment,
+            "latency": latency,
+            "latencies": list(self._latencies),
+            "turn_count": self._turn_count,
+            "participation": dict(self._participation),
+            "tool_usage": {
+                agent: dict(counter) for agent, counter in self._tool_usage.items()
+            },
+            "tool_usage_events": list(self._tool_usage_events),
+            "timestamp": now,
+        }
+
         for metric_name, metric_function in self.metrics.items():
-            value = metric_function(agents, environment)
+            try:
+                value = metric_function(agent_list, environment, context=context)
+            except TypeError:
+                value = metric_function(agent_list, environment)
             self.data[metric_name].append(value)
-            
-    def export_to_csv(self, filename):
-        with open(filename, 'w', newline='') as csvfile:
+
+    def export_to_csv(self, filename: str) -> None:
+        with open(filename, "w", newline="") as csvfile:
             writer = csv.writer(csvfile)
             for key, value in self.data.items():
                 writer.writerow([key] + value)
 
-    def export_to_json(self, filename):
-        with open(filename, 'w') as jsonfile:
-            json.dump(self.data, jsonfile)
+    def export_to_json(self, filename: str) -> None:
+        with open(filename, "w") as jsonfile:
+            json.dump(self.data, jsonfile, default=self._json_default)
+
+    def to_dict(self) -> Dict[str, List[Any]]:
+        """Return the collected metric history as a serialisable dictionary."""
+
+        return json.loads(json.dumps(self.data, default=self._json_default))
+
+    def latest_snapshot(self) -> Dict[str, Any]:
+        """Return the most recent value for each tracked metric."""
+
+        return {name: values[-1] if values else None for name, values in self.data.items()}
+
+    def log_to_mlflow(
+        self,
+        *,
+        step: Optional[int] = None,
+        prefix: str = "neva",
+    ) -> None:
+        """Log the most recent metrics to an active MLflow run.
+
+        Parameters
+        ----------
+        step:
+            Optional step value to associate with the logged metrics.
+        prefix:
+            Namespace prefix applied to metric names to avoid collisions.
+        """
+
+        try:
+            import mlflow  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency.
+            raise RuntimeError(
+                "MLflow is not installed. Install `mlflow` or disable dashboard "
+                "logging to continue."
+            ) from exc
+
+        snapshot = self.latest_snapshot()
+        for metric_name, value in snapshot.items():
+            key = f"{prefix}/{metric_name}"
+            if isinstance(value, (int, float)):
+                mlflow.log_metric(key, float(value), step=step)
+            else:
+                mlflow.log_param(key, json.dumps(value, default=self._json_default))
+
+    # ------------------------------------------------------------------
+    # Observation helpers used by the schedulers/agents
+    # ------------------------------------------------------------------
+    def watch_agent(self, agent: Any) -> None:
+        """Initialise counters and tool instrumentation for ``agent``."""
+
+        agent_name = getattr(agent, "name", str(agent))
+        self._participation.setdefault(agent_name, 0)
+        self._tool_usage.setdefault(agent_name, Counter())
+        for tool in getattr(agent, "tools", []):
+            self.watch_tool(agent, tool)
+
+    def watch_tool(self, agent: Any, tool: Any) -> None:
+        """Wrap ``tool.use`` to record usage statistics when available."""
+
+        if tool is None:
+            return
+
+        tool_id = id(tool)
+        if tool_id in self._wrapped_tools:
+            return
+
+        original_use = getattr(tool, "use")
+
+        @wraps(original_use)
+        def instrumented_use(self_tool, *args: Any, **kwargs: Any) -> Any:
+            start = perf_counter()
+            try:
+                return original_use(*args, **kwargs)
+            finally:
+                duration = perf_counter() - start
+                self.record_tool_usage(agent, self_tool, duration=duration)
+
+        tool.use = MethodType(instrumented_use, tool)  # type: ignore[assignment]
+        self._wrapped_tools[tool_id] = original_use
+
+    def record_tool_usage(self, agent: Any, tool: Any, *, duration: Optional[float] = None) -> None:
+        """Record a tool invocation emitted by the instrumentation wrapper."""
+
+        agent_name = getattr(agent, "name", str(agent))
+        tool_name = getattr(tool, "name", getattr(tool, "__class__", type(tool)).__name__)
+        self._tool_usage[agent_name][tool_name] += 1
+        event = {
+            "agent": agent_name,
+            "tool": tool_name,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        if duration is not None:
+            event["duration_seconds"] = duration
+        self._tool_usage_events.append(event)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _json_default(self, value: Any) -> Any:
+        if isinstance(value, (datetime,)):
+            return value.isoformat()
+        if isinstance(value, Counter):
+            return dict(value)
+        if isinstance(value, Mapping):
+            return dict(value)
+        return value
+
+    def _register_builtin_metrics(self) -> None:
+        self.add_metric("turn_count", lambda agents, env, *, context=None: context.get("turn_count") if context else self._turn_count)
+
+        def participation_metric(_agents, _env, *, context=None):
+            if context is None:
+                return dict(self._participation)
+            return context["participation"]
+
+        self.add_metric("per_agent_participation", participation_metric)
+
+        def active_agent_metric(_agents, _env, *, context=None):
+            if context is None:
+                return self._latest_agent_name
+            return context.get("active_agent_name")
+
+        self.add_metric("active_agent", active_agent_metric)
+
+        def dialogue_length_metric(_agents, environment, *, context=None):
+            transcript = self._extract_transcript(environment)
+            return _safe_len(transcript)
+
+        self.add_metric("dialogue_length", dialogue_length_metric)
+
+        def latency_metric(_agents, _env, *, context=None):
+            if context is None:
+                return self._latest_latency
+            return context.get("latency")
+
+        self.add_metric("latest_response_latency_seconds", latency_metric)
+
+        def average_latency_metric(_agents, _env, *, context=None):
+            latencies = context.get("latencies") if context else self._latencies
+            if not latencies:
+                return None
+            return sum(latencies) / len(latencies)
+
+        self.add_metric("average_response_latency_seconds", average_latency_metric)
+
+        def tool_usage_metric(_agents, _env, *, context=None):
+            usage = context.get("tool_usage") if context else {
+                agent: dict(counter) for agent, counter in self._tool_usage.items()
+            }
+            return usage
+
+        self.add_metric("tool_usage_counts", tool_usage_metric)
+
+        def sentiment_metric(_agents, environment, *, context=None):
+            message = self._extract_latest_message(environment)
+            if not message:
+                return {"score": 0.0, "label": "neutral"}
+            score = self._compute_sentiment(message)
+            label = "positive" if score > 0 else "negative" if score < 0 else "neutral"
+            return {"score": score, "label": label}
+
+        self.add_metric("recent_sentiment", sentiment_metric)
+
+        def intent_metric(_agents, environment, *, context=None):
+            message = self._extract_latest_message(environment)
+            if not message:
+                return "unknown"
+            stripped = message.strip()
+            if stripped.endswith("?"):
+                return "question"
+            lowered = stripped.lower()
+            if lowered.startswith("let's") or "let us" in lowered or lowered.startswith("please"):
+                return "collaboration"
+            if any(lowered.startswith(prefix) for prefix in ("do ", "please", "consider", "review")):
+                return "request"
+            if any(lowered.startswith(prefix) for prefix in ("plan", "we should", "let's")):
+                return "planning"
+            return "statement"
+
+        self.add_metric("recent_intent", intent_metric)
+
+    def _extract_transcript(self, environment: Optional[Any]) -> List[str]:
+        if environment is None:
+            return []
+        transcript = getattr(environment, "transcript", None)
+        if transcript is None and hasattr(environment, "state"):
+            transcript = environment.state.get("transcript")  # type: ignore[assignment]
+        if transcript is None:
+            return []
+        if isinstance(transcript, list):
+            return transcript
+        try:
+            return list(transcript)
+        except TypeError:
+            logger.debug("Transcript attribute %r is not iterable", transcript)
+            return []
+
+    def _extract_latest_message(self, environment: Optional[Any]) -> Optional[str]:
+        transcript = self._extract_transcript(environment)
+        if not transcript:
+            return None
+        latest = transcript[-1]
+        return str(latest) if latest is not None else None
+
+    def _compute_sentiment(self, message: str) -> float:
+        words = [token.strip(".,!?") for token in message.lower().split()]
+        positive = sum(word in self._sentiment_positive_words for word in words)
+        negative = sum(word in self._sentiment_negative_words for word in words)
+        total = positive + negative
+        if total == 0:
+            if not self._sentiment_warning_emitted:
+                logger.debug(
+                    "Sentiment word lists produced a neutral score for message: %s", message
+                )
+                self._sentiment_warning_emitted = True
+            return 0.0
+        return (positive - negative) / total

--- a/schedulers.py
+++ b/schedulers.py
@@ -20,7 +20,7 @@ class RandomScheduler(Scheduler):
         if not self.agents:
             raise RuntimeError("RandomScheduler has no agents to schedule.")
         agent = random.choice(self.agents)
-        self.record_metrics()
+        self.record_metrics(agent)
         return agent
 
 
@@ -40,7 +40,7 @@ class RoundRobinScheduler(Scheduler):
             raise RuntimeError("RoundRobinScheduler has no agents to schedule.")
         agent = self.agents[self.current_index]
         self.current_index = (self.current_index + 1) % len(self.agents)
-        self.record_metrics()
+        self.record_metrics(agent)
         return agent
 
 
@@ -65,7 +65,7 @@ class PriorityScheduler(Scheduler):
         priority, agent = self._queue.pop(0)
         # Reinsert agent with same priority for future scheduling
         self._queue.append((priority, agent))
-        self.record_metrics()
+        self.record_metrics(agent)
         return agent
 
 class LeastRecentlyUsedScheduler(Scheduler):
@@ -85,7 +85,7 @@ class LeastRecentlyUsedScheduler(Scheduler):
             raise RuntimeError("LeastRecentlyUsedScheduler has no agents to schedule.")
         agent = self._queue.pop(0)
         self._queue.append(agent)
-        self.record_metrics()
+        self.record_metrics(agent)
         return agent
 
 class WeightedRandomScheduler(Scheduler):
@@ -109,11 +109,11 @@ class WeightedRandomScheduler(Scheduler):
         random_weight = random.uniform(0, total_weight)
         for weight, agent in self._entries:
             if random_weight <= weight:
-                self.record_metrics()
+                self.record_metrics(agent)
                 return agent
             random_weight -= weight
 
         # Fallback due to floating point rounding.
         agent = self._entries[-1][1]
-        self.record_metrics()
+        self.record_metrics(agent)
         return agent

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,5 +1,8 @@
+import json
 import os
 import sys
+from types import SimpleNamespace
+
 import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -7,7 +10,7 @@ from observer import SimulationObserver
 
 
 def test_collects_metrics():
-    obs = SimulationObserver()
+    obs = SimulationObserver(enable_builtin_metrics=False)
     # metric returns number of agents
     obs.add_metric("count", lambda agents, env: len(agents))
     agents = [1, 2, 3]
@@ -16,7 +19,7 @@ def test_collects_metrics():
 
 
 def test_export_to_csv(tmp_path):
-    obs = SimulationObserver()
+    obs = SimulationObserver(enable_builtin_metrics=False)
     obs.add_metric("turns", lambda agents, env: len(agents))
     obs.collect_data(["agent"], None)
 
@@ -27,13 +30,61 @@ def test_export_to_csv(tmp_path):
 
 
 def test_export_to_json(tmp_path):
-    obs = SimulationObserver()
+    obs = SimulationObserver(enable_builtin_metrics=False)
     obs.add_metric("messages", lambda agents, env: [agent for agent in agents])
     obs.collect_data(["A", "B"], None)
 
     json_path = tmp_path / "metrics.json"
     obs.export_to_json(json_path)
 
-    import json
-
     assert json.loads(json_path.read_text()) == {"messages": [["A", "B"]]}
+
+
+def test_builtin_metrics_compute_turns_and_participation():
+    obs = SimulationObserver()
+    agent = SimpleNamespace(name="Explorer")
+    environment = SimpleNamespace(transcript=["Hello", "How are you?"], state={})
+
+    obs.watch_agent(agent)
+    obs.collect_data([agent], environment, active_agent=agent)
+
+    snapshot = obs.latest_snapshot()
+    assert snapshot["turn_count"] == 1
+    assert snapshot["per_agent_participation"]["Explorer"] == 1
+    assert snapshot["dialogue_length"] == 2
+    assert snapshot["recent_intent"] == "question"
+
+
+def test_tool_usage_is_instrumented():
+    class DummyTool:
+        name = "dummy"
+
+        def use(self, task):
+            return task.upper()
+
+    agent = SimpleNamespace(name="Explorer", tools=[])
+    env = SimpleNamespace(transcript=[], state={})
+
+    obs = SimulationObserver()
+    obs.watch_agent(agent)
+    tool = DummyTool()
+    agent.tools.append(tool)
+    obs.watch_tool(agent, tool)
+
+    tool.use("ping")
+    obs.collect_data([agent], env, active_agent=agent)
+
+    snapshot = obs.latest_snapshot()
+    assert snapshot["tool_usage_counts"]["Explorer"]["dummy"] == 1
+
+
+def test_log_to_mlflow_requires_dependency(monkeypatch):
+    obs = SimulationObserver()
+    obs.collect_data([], None)
+
+    monkeypatch.setitem(sys.modules, "mlflow", None)
+
+    with pytest.raises(RuntimeError) as exc:
+        obs.log_to_mlflow()
+
+    assert "MLflow is not installed" in str(exc.value)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -39,5 +39,7 @@ def test_wikipedia_tool_missing_dependency_raises(monkeypatch):
         pytest.skip("Unexpected module location")
 
     monkeypatch.setattr("tools.wikipedia", None)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as exc:
         tool.use("Python (programming language)")
+
+    assert "pip install wikipedia" in str(exc.value)


### PR DESCRIPTION
## Summary
- add built-in SimulationObserver metrics with tool instrumentation, latency tracking, and MLflow export helpers
- update the quickstart example and README to highlight automatic metric collection and graceful tooling fallbacks
- improve optional tool dependency error messages and extend the observer/tool test suites

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ea331b1cd483238e786e0c1bf03852