### PR TITLE
Add lifecycle controls and composite scheduler

### DIFF
--- a/models.py
+++ b/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Set
 from uuid import uuid4
 
 import openai
@@ -371,6 +371,8 @@ class Scheduler(ABC):
     def __init__(self) -> None:
         self.agents: List[AIAgent] = []
         self.environment: Optional["Environment"] = None
+        self._paused_agents: Set[AIAgent] = set()
+        self._termination_hooks: List[Callable[[AIAgent], None]] = []
 
     def set_environment(self, environment: "Environment") -> None:
         self.environment = environment
@@ -387,6 +389,54 @@ class Scheduler(ABC):
                 # ``active_agent`` keyword argument (for example, monkeypatched
                 # tests).
                 observer.collect_data(list(self.agents), self.environment)
+
+    # ------------------------------------------------------------------
+    # Agent lifecycle controls
+    # ------------------------------------------------------------------
+    def register_termination_hook(self, hook: Callable[[AIAgent], None]) -> None:
+        """Invoke ``hook`` whenever an agent is terminated."""
+
+        self._termination_hooks.append(hook)
+
+    def pause(self, agent: AIAgent) -> None:
+        """Temporarily remove ``agent`` from the active scheduling pool."""
+
+        if agent in self.agents:
+            self._paused_agents.add(agent)
+
+    def resume(self, agent: AIAgent) -> None:
+        """Return ``agent`` to the active scheduling pool."""
+
+        self._paused_agents.discard(agent)
+
+    def is_paused(self, agent: AIAgent) -> bool:
+        """Return ``True`` when ``agent`` is currently paused."""
+
+        return agent in self._paused_agents
+
+    def terminate(self, agent: AIAgent) -> None:
+        """Remove ``agent`` from the scheduler and trigger termination hooks."""
+
+        if agent not in self.agents:
+            return
+
+        self.agents = [existing for existing in self.agents if existing is not agent]
+        self._paused_agents.discard(agent)
+        self._handle_agent_removal(agent)
+        for hook in list(self._termination_hooks):
+            hook(agent)
+
+    def _handle_agent_removal(self, agent: AIAgent) -> None:
+        """Allow subclasses to update internal state after ``agent`` removal."""
+
+        # Subclasses override as necessary. The base implementation intentionally
+        # does nothing.
+        return
+
+    def _active_agents(self) -> List[AIAgent]:
+        """Return the list of agents that are not currently paused."""
+
+        return [agent for agent in self.agents if agent not in self._paused_agents]
 
     @abstractmethod
     def add(self, agent: AIAgent, **kwargs) -> None:

--- a/schedulers.py
+++ b/schedulers.py
@@ -1,7 +1,7 @@
 """Scheduler implementations for controlling agent execution order."""
 
 import random
-from typing import List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 from models import AIAgent, Scheduler
 from observer import SimulationObserver
@@ -14,12 +14,14 @@ class RandomScheduler(Scheduler):
         self.simulation_observer = SimulationObserver()
 
     def add(self, agent: AIAgent, **_: object) -> None:
-        self.agents.append(agent)
+        if agent not in self.agents:
+            self.agents.append(agent)
 
     def get_next_agent(self) -> AIAgent:
-        if not self.agents:
-            raise RuntimeError("RandomScheduler has no agents to schedule.")
-        agent = random.choice(self.agents)
+        active_agents = self._active_agents()
+        if not active_agents:
+            raise RuntimeError("RandomScheduler has no active agents to schedule.")
+        agent = random.choice(active_agents)
         self.record_metrics(agent)
         return agent
 
@@ -33,15 +35,29 @@ class RoundRobinScheduler(Scheduler):
         self.current_index = 0
 
     def add(self, agent: AIAgent, **_: object) -> None:
-        self.agents.append(agent)
+        if agent not in self.agents:
+            self.agents.append(agent)
 
     def get_next_agent(self) -> AIAgent:
         if not self.agents:
             raise RuntimeError("RoundRobinScheduler has no agents to schedule.")
-        agent = self.agents[self.current_index]
-        self.current_index = (self.current_index + 1) % len(self.agents)
-        self.record_metrics(agent)
-        return agent
+
+        total_agents = len(self.agents)
+        for _ in range(total_agents):
+            agent = self.agents[self.current_index]
+            self.current_index = (self.current_index + 1) % total_agents
+            if self.is_paused(agent):
+                continue
+            self.record_metrics(agent)
+            return agent
+
+        raise RuntimeError("RoundRobinScheduler has no active agents to schedule.")
+
+    def _handle_agent_removal(self, agent: AIAgent) -> None:
+        if not self.agents:
+            self.current_index = 0
+            return
+        self.current_index %= len(self.agents)
 
 
 class PriorityScheduler(Scheduler):
@@ -61,12 +77,20 @@ class PriorityScheduler(Scheduler):
     def get_next_agent(self) -> AIAgent:
         if not self._queue:
             raise RuntimeError("PriorityScheduler has no agents to schedule.")
+
         self._queue.sort(reverse=True)
-        priority, agent = self._queue.pop(0)
-        # Reinsert agent with same priority for future scheduling
-        self._queue.append((priority, agent))
-        self.record_metrics(agent)
-        return agent
+        for _ in range(len(self._queue)):
+            priority, agent = self._queue.pop(0)
+            self._queue.append((priority, agent))
+            if self.is_paused(agent):
+                continue
+            self.record_metrics(agent)
+            return agent
+
+        raise RuntimeError("PriorityScheduler has no active agents to schedule.")
+
+    def _handle_agent_removal(self, agent: AIAgent) -> None:
+        self._queue = [(priority, queued) for priority, queued in self._queue if queued is not agent]
 
 class LeastRecentlyUsedScheduler(Scheduler):
     """Activate the agent that has waited the longest."""
@@ -77,16 +101,29 @@ class LeastRecentlyUsedScheduler(Scheduler):
         self._queue: List[AIAgent] = []
 
     def add(self, agent: AIAgent, **_: object) -> None:
-        self.agents.append(agent)
-        self._queue.append(agent)
+        if agent not in self.agents:
+            self.agents.append(agent)
+            self._queue.append(agent)
+        elif agent not in self._queue:
+            self._queue.append(agent)
 
     def get_next_agent(self) -> AIAgent:
         if not self._queue:
             raise RuntimeError("LeastRecentlyUsedScheduler has no agents to schedule.")
-        agent = self._queue.pop(0)
-        self._queue.append(agent)
-        self.record_metrics(agent)
-        return agent
+
+        total_considered = len(self._queue)
+        for _ in range(total_considered):
+            agent = self._queue.pop(0)
+            self._queue.append(agent)
+            if self.is_paused(agent):
+                continue
+            self.record_metrics(agent)
+            return agent
+
+        raise RuntimeError("LeastRecentlyUsedScheduler has no active agents to schedule.")
+
+    def _handle_agent_removal(self, agent: AIAgent) -> None:
+        self._queue = [queued for queued in self._queue if queued is not agent]
 
 class WeightedRandomScheduler(Scheduler):
     """Activate agents randomly according to provided weights."""
@@ -105,15 +142,144 @@ class WeightedRandomScheduler(Scheduler):
     def get_next_agent(self) -> AIAgent:
         if not self._entries:
             raise RuntimeError("WeightedRandomScheduler has no agents to schedule.")
-        total_weight = sum(weight for weight, _ in self._entries)
+
+        active_entries = [(weight, agent) for weight, agent in self._entries if not self.is_paused(agent)]
+        if not active_entries:
+            raise RuntimeError("WeightedRandomScheduler has no active agents to schedule.")
+
+        total_weight = sum(weight for weight, _ in active_entries)
         random_weight = random.uniform(0, total_weight)
-        for weight, agent in self._entries:
+        for weight, agent in active_entries:
             if random_weight <= weight:
                 self.record_metrics(agent)
                 return agent
             random_weight -= weight
 
         # Fallback due to floating point rounding.
-        agent = self._entries[-1][1]
+        agent = active_entries[-1][1]
         self.record_metrics(agent)
         return agent
+
+    def _handle_agent_removal(self, agent: AIAgent) -> None:
+        self._entries = [(weight, queued) for weight, queued in self._entries if queued is not agent]
+
+
+class CompositeScheduler(Scheduler):
+    """Coordinate multiple sub-schedulers managing agent sub-groups."""
+
+    def __init__(self, group_scheduler_factory: Optional[Callable[[], Scheduler]] = None) -> None:
+        super().__init__()
+        self.simulation_observer = SimulationObserver()
+        self._group_scheduler_factory: Callable[[], Scheduler] = (
+            group_scheduler_factory or RoundRobinScheduler
+        )
+        self._group_schedulers: Dict[str, Scheduler] = {}
+        self._group_membership: Dict[AIAgent, str] = {}
+        self._group_order: List[str] = []
+        self._group_index = 0
+
+    def set_environment(self, environment) -> None:
+        super().set_environment(environment)
+        for scheduler in self._group_schedulers.values():
+            scheduler.set_environment(environment)
+
+    def add(self, agent: AIAgent, **kwargs) -> None:
+        group = kwargs.pop("group", "default")
+        scheduler_override = kwargs.pop("scheduler", None)
+        group_scheduler = self._ensure_group_scheduler(group, scheduler_override)
+
+        if agent not in self.agents:
+            self.agents.append(agent)
+
+        self._group_membership[agent] = group
+        group_scheduler.add(agent, **kwargs)
+        # Ensure paused state propagates if the agent was previously paused.
+        if self.is_paused(agent):
+            group_scheduler.pause(agent)
+
+    def pause(self, agent: AIAgent) -> None:
+        super().pause(agent)
+        group = self._group_membership.get(agent)
+        if group is not None:
+            self._group_schedulers[group].pause(agent)
+
+    def resume(self, agent: AIAgent) -> None:
+        super().resume(agent)
+        group = self._group_membership.get(agent)
+        if group is not None:
+            self._group_schedulers[group].resume(agent)
+
+    def terminate(self, agent: AIAgent) -> None:
+        group = self._group_membership.pop(agent, None)
+        if group is not None and group in self._group_schedulers:
+            self._group_schedulers[group].terminate(agent)
+            if not self._group_schedulers[group].agents:
+                self._remove_group(group)
+        super().terminate(agent)
+
+    def get_next_agent(self) -> AIAgent:
+        if not self._group_order:
+            raise RuntimeError("CompositeScheduler has no agents to schedule.")
+
+        visited_groups = 0
+        total_groups = len(self._group_order)
+
+        while visited_groups < total_groups:
+            group_name = self._group_order[self._group_index]
+            scheduler = self._group_schedulers[group_name]
+            self._group_index = (self._group_index + 1) % total_groups
+            try:
+                agent = scheduler.get_next_agent()
+            except RuntimeError:
+                visited_groups += 1
+                continue
+
+            if agent is None or self.is_paused(agent):
+                visited_groups += 1
+                continue
+
+            self.record_metrics(agent)
+            return agent
+
+        raise RuntimeError("CompositeScheduler has no active agents to schedule.")
+
+    def _ensure_group_scheduler(
+        self, group: str, scheduler_override: Optional[Scheduler]
+    ) -> Scheduler:
+        if group in self._group_schedulers:
+            if scheduler_override is not None and scheduler_override is not self._group_schedulers[group]:
+                raise ValueError(f"Group '{group}' already has an assigned scheduler.")
+            return self._group_schedulers[group]
+
+        scheduler = scheduler_override or self._group_scheduler_factory()
+        # Avoid nested schedulers double-counting metrics. The composite scheduler
+        # records metrics once agents are selected.
+        if hasattr(scheduler, "simulation_observer"):
+            scheduler.simulation_observer = None  # type: ignore[assignment]
+        scheduler.set_environment(self.environment)
+        self._group_schedulers[group] = scheduler
+        self._group_order.append(group)
+        self._group_index %= len(self._group_order)
+        return scheduler
+
+    def _remove_group(self, group: str) -> None:
+        if group not in self._group_schedulers:
+            return
+        self._group_schedulers.pop(group)
+        if group in self._group_order:
+            index = self._group_order.index(group)
+            self._group_order.pop(index)
+            if self._group_order:
+                self._group_index %= len(self._group_order)
+            else:
+                self._group_index = 0
+
+    def _handle_agent_removal(self, agent: AIAgent) -> None:
+        group = self._group_membership.pop(agent, None)
+        if group is None:
+            return
+        scheduler = self._group_schedulers.get(group)
+        if scheduler is not None and agent in scheduler.agents:
+            scheduler.terminate(agent)
+            if not scheduler.agents:
+                self._remove_group(group)

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -4,7 +4,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from models import AIAgent
-from schedulers import PriorityScheduler, RoundRobinScheduler
+from schedulers import CompositeScheduler, PriorityScheduler, RoundRobinScheduler
 
 
 class StubAgent(AIAgent):
@@ -40,3 +40,46 @@ def test_priority_scheduler_picks_highest_priority_first():
     another_low = StubAgent("another_low")
     scheduler.add(another_low, priority=2)
     assert scheduler.get_next_agent() is high
+
+
+def test_scheduler_pause_and_resume_controls_activation():
+    scheduler = RoundRobinScheduler()
+    agents = [StubAgent("A"), StubAgent("B"), StubAgent("C")]
+    for agent in agents:
+        scheduler.add(agent)
+
+    scheduler.pause(agents[1])
+    cycle = [scheduler.get_next_agent() for _ in range(4)]
+    assert [agent.name for agent in cycle] == ["A", "C", "A", "C"]
+
+    scheduler.resume(agents[1])
+    resumed_cycle = [scheduler.get_next_agent() for _ in range(3)]
+    assert [agent.name for agent in resumed_cycle] == ["A", "B", "C"]
+    assert agents[1] in resumed_cycle
+
+
+def test_scheduler_termination_hooks_execute_on_remove():
+    scheduler = PriorityScheduler()
+    agent = StubAgent("hooked")
+    events = []
+
+    scheduler.register_termination_hook(lambda removed: events.append(removed.name))
+    scheduler.add(agent, priority=1)
+    scheduler.terminate(agent)
+
+    assert events == ["hooked"]
+    assert agent not in scheduler.agents
+
+
+def test_composite_scheduler_balances_groups():
+    scheduler = CompositeScheduler()
+    group_one_agents = [StubAgent("A"), StubAgent("B")]
+    group_two_agents = [StubAgent("C")]
+
+    for agent in group_one_agents:
+        scheduler.add(agent, group="alpha")
+    for agent in group_two_agents:
+        scheduler.add(agent, group="beta")
+
+    turns = [scheduler.get_next_agent() for _ in range(5)]
+    assert [agent.name for agent in turns] == ["A", "C", "B", "C", "A"]


### PR DESCRIPTION
## Summary
- add scheduler lifecycle controls supporting pause/resume, termination hooks, and active-agent filtering
- update concrete schedulers and introduce a composite scheduler for group orchestration
- expand scheduler tests to cover lifecycle management and composite behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ea36cdb07883238260996c62e73d65