### PR TITLE
Fix agent prompt memory recall behavior

### DIFF
--- a/models.py
+++ b/models.py
@@ -149,7 +149,7 @@ class AIAgent(ABC):
     def prepare_prompt(self, message: str) -> str:
         """Compose a prompt enriched with agent attributes and tool context."""
 
-        memory_context = self.recall_memory(query=message)
+        memory_context = self.recall_memory()
         parts = [self.generate_attribute_summary(), self.generate_tool_summary()]
         if memory_context:
             parts.append(f"Relevant memory -> {memory_context}")


### PR DESCRIPTION
## Summary
- update agent prompt construction to recall full memory context instead of filtering by the latest message

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea3b928cf08323a9afb446b22c3e93