### PR TITLE
Modernize optional tools and add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.log
+.env
+.venv/
+build/
+dist/
+.git/
+.gitignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,8 @@ Before diving in, we recommend spending some time understanding the goals and ar
 ## Setting Up the Development Environment
 - **Fork the Repository:** Start by forking the Neva repository to your GitHub account.
 - **Clone Your Fork:** Clone your fork to your local machine.
-- **Install Dependencies:** Follow the installation guide in the README.
+- **Install Dependencies:** Run `poetry install --with dev` (or follow the
+  installation guide in the README for alternative workflows).
 - **Create a Branch:** Create a new branch for your changes, keeping your work separate.
 
 ## Submitting a Pull Request

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.4
+FROM python:3.10-slim AS runtime
+
+ARG POETRY_VERSION=1.6.1
+ARG WITH_EXTRAS=""
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN apt-get update \ \
+    && apt-get install --no-install-recommends -y build-essential curl \ \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir "poetry==${POETRY_VERSION}"
+
+WORKDIR /workspace
+
+COPY pyproject.toml poetry.lock* README.md ./
+COPY neva ./neva
+COPY examples ./examples
+COPY tests ./tests
+COPY requirements*.txt ./
+COPY CONTRIBUTING.md CHANGELOG.md CODE_OF_CONDUCT.md LICENSE ./
+
+RUN set -eux; \
+    poetry config virtualenvs.create false; \
+    extras=""; \
+    if [ -n "${WITH_EXTRAS}" ]; then \
+        for extra in $(echo "${WITH_EXTRAS}" | tr ',' ' '); do \
+            extras="${extras} --extras ${extra}"; \
+        done; \
+    fi; \
+    poetry install --no-interaction ${extras}
+
+CMD ["python"]

--- a/README.md
+++ b/README.md
@@ -79,28 +79,26 @@ or logged to MLflow with `SimulationObserver.log_to_mlflow()` to integrate with
 your preferred dashboarding stack.
 
 ## Installation
-Clone the repository and install the required packages:
+Clone the repository and install dependencies with [Poetry](https://python-poetry.org/):
 
 ```bash
 git clone https://github.com/davletovb/neva.git
 cd neva
-pip install -r requirements.txt
+poetry install
 ```
 
-The core requirements focus on lightweight, always-on dependencies. Optional
-extras such as `transformers` and `bert-extractive-summarizer` moved to
-`requirements-optional.txt` so you only install heavy packages when necessary.
-For development workflows install the tooling bundle:
+Poetry keeps the default installation lean—only the always-on dependencies ship
+with the core project. Install additional bundles as needed:
 
-```bash
-pip install -r requirements-dev.txt
-```
+- **Development tools** – `poetry install --with dev`
+- **Research tools (translation, summarisation, encyclopedia lookups)** –
+  `poetry install --extras "tools"`
+- **ML experiment tracking** – `poetry install --extras "mlops"`
+- **Everything** – `poetry install --extras "all" --with dev`
 
-and pull in heavyweight integrations on demand:
-
-```bash
-pip install -r requirements-optional.txt
-```
+Prefer `pip`? The same extras are available via `pip install .[tools]` or
+`pip install .[all]`. Updated `requirements-*.txt` files are provided for
+environments that cannot yet adopt Poetry.
 
 ### Developer Setup
 
@@ -116,17 +114,33 @@ configuration steps:
 - **Environment variables** – place sensitive credentials (API keys, database
   URLs, etc.) in a `.env` file and load them via `python-dotenv` or your
   preferred secrets manager when running examples.
-- **Optional heavyweight dependencies** – examples that rely on summarisation or
-  translation tools use `bert-extractive-summarizer` and `googletrans`. Install
-  them only when needed to keep the core installation lightweight.
+- **Optional heavyweight dependencies** – translation is powered by
+  `deep-translator` (a maintained wrapper around the Google Translate service) and
+  summarisation leverages Hugging Face's `transformers` (T5 by default). Install
+  the `tools` extra—or the individual packages—only when you require these
+  capabilities to keep the core installation lightweight.
 - **Structured logging** – call ``logging_utils.configure_logging()`` at the
   beginning of your experiment to emit JSON logs ready for ingestion by ELK,
   Loki, or any observability platform.
 - **Graceful fallbacks** – the built-in tools surface actionable error messages
-  when optional packages such as `wikipedia`, `googletrans`, or
-  `bert-extractive-summarizer` are unavailable. You can provide lightweight
-  factories to `TranslatorTool` and `SummarizerTool` (or monkeypatch the
+  when optional packages such as `wikipedia`, `deep-translator`, or
+  `transformers` are unavailable. You can provide lightweight factories to
+  `TranslatorTool` and `SummarizerTool` (or monkeypatch the
   Wikipedia backend) to keep experiments fully offline.
+
+### Docker
+
+Need a reproducible runtime? Build the included container image:
+
+```bash
+docker build -t neva:latest .
+docker run --rm -it neva:latest python examples/quickstart_conversation.py
+```
+
+The Dockerfile uses Poetry to install the project and accepts optional build
+arguments (`WITH_EXTRAS=tools,mlops`) to bake in additional extras when
+required. Mount your local workspace with `-v $PWD:/workspace` for rapid
+iteration.
 
 After installing dependencies run `pytest` to confirm the environment is ready
 for development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,39 @@
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["poetry-core>=1.6.1"]
+build-backend = "poetry.core.masonry.api"
 
-[project]
+[tool.poetry]
 name = "neva"
 version = "0.1.0"
 description = "Neva provides agent, environment, and scheduler abstractions for LLM-based simulations."
+authors = ["Neva Contributors"]
 readme = "README.md"
-requires-python = ">=3.8"
-authors = [{name = "Neva Contributors"}]
+license = "MIT"
+packages = [{ include = "neva" }]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+openai = "0.28.1"
+wikipedia = { version = "1.4.0", optional = true }
+"deep-translator" = { version = "^1.11.4", optional = true }
+transformers = { version = "^4.35.2", optional = true }
+mlflow = { version = "^2.9.1", optional = true }
+
+[tool.poetry.group.dev.dependencies]
+black = "23.9.1"
+coverage = "7.3.2"
+mypy = "1.6.1"
+pytest = "7.4.2"
+
+[tool.poetry.extras]
+tools = ["wikipedia", "deep-translator", "transformers"]
+mlops = ["mlflow"]
+all = ["wikipedia", "deep-translator", "transformers", "mlflow"]
+
+[tool.black]
+line-length = 100
+target-version = ["py38"]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,3 +1,4 @@
+wikipedia==1.4.0
+deep-translator==1.11.4
 transformers==4.35.2
-bert-extractive-summarizer==0.10.1
 mlflow==2.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
 openai==0.28.1
-wikipedia==1.4.0
-googletrans==4.0.0rc1


### PR DESCRIPTION
## Summary
- replace the googletrans-based translator with a deep-translator backend and move summarisation to a Hugging Face T5 pipeline
- migrate dependency management to Poetry with optional extras for heavyweight tools and refresh contributor documentation
- add Docker tooling (.dockerignore and Dockerfile) for reproducible, Poetry-driven environments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ece622be8c83238fcf6955df38d316