### PR TITLE
Add multi-provider support to GPT agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,13 @@ with the core project. Install additional bundles as needed:
 - **Research tools (translation, summarisation, encyclopedia lookups)** –
   `poetry install --extras "tools"`
 - **ML experiment tracking** – `poetry install --extras "mlops"`
+- **Additional LLM providers (Anthropic Claude, Google Gemini, xAI Grok)** –
+  `poetry install --extras "providers"`
 - **Everything** – `poetry install --extras "all" --with dev`
 
-Prefer `pip`? The same extras are available via `pip install .[tools]` or
-`pip install .[all]`. Updated `requirements-*.txt` files are provided for
+Prefer `pip`? The same extras are available via `pip install .[tools]`,
+`pip install .[providers]`, or `pip install .[all]`. Updated
+`requirements-*.txt` files are provided for
 environments that cannot yet adopt Poetry.
 
 ### Developer Setup
@@ -105,9 +108,12 @@ environments that cannot yet adopt Poetry.
 To contribute or run the full suite of examples you may need a few additional
 configuration steps:
 
-- **API keys** – set `OPENAI_API_KEY` (or pass `api_key` directly) when using
-  `GPTAgent`. Community members often rely on [OpenAI compatible endpoints](https://platform.openai.com/docs/api-reference/introduction), but any drop-in
-  replacement that matches the Chat Completions API works.
+- **API keys** – supply the relevant key (`OPENAI_API_KEY`,
+  `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, or an xAI token) when using
+  `GPTAgent`. Select a backend by passing `provider="openai"`,
+  `"anthropic"`, `"gemini"`, or `"grok"`. Community members often rely on
+  [OpenAI compatible endpoints](https://platform.openai.com/docs/api-reference/introduction), but any drop-in replacement that matches the Chat
+  Completions API works.
 - **Transformers cache** – the `TransformerAgent` loads Hugging Face models on
   demand. Install the optional `torch` dependency and authenticate with
   `huggingface-cli login` if you plan to download private models.

--- a/neva/agents/gpt.py
+++ b/neva/agents/gpt.py
@@ -1,12 +1,14 @@
-"""OpenAI-compatible GPT agent implementation."""
+"""Large language model agent with support for multiple providers."""
 
 from __future__ import annotations
 
+import importlib
 import logging
 from time import perf_counter, sleep
-from typing import Optional
+from typing import Dict, Optional
 
 import openai
+import requests
 
 from neva.agents.base import AIAgent, LLMBackend
 from neva.memory import MemoryModule
@@ -17,13 +19,14 @@ from neva.utils.safety import RateLimiter
 
 
 class GPTAgent(AIAgent):
-    """Agent that communicates with an OpenAI-compatible large language model."""
+    """Agent that communicates with a large language model provider."""
 
     def __init__(
         self,
         *,
         api_key: Optional[str] = None,
         model: str = "gpt-3.5-turbo",
+        provider: str = "openai",
         name: Optional[str] = None,
         llm_backend: Optional[LLMBackend] = None,
         memory: Optional[MemoryModule] = None,
@@ -34,6 +37,10 @@ class GPTAgent(AIAgent):
         max_retries: int = 3,
         retry_backoff: float = 1.5,
         response_time_tracker: Optional[ResponseTimeTracker] = None,
+        max_output_tokens: int = 1024,
+        api_base: Optional[str] = None,
+        request_timeout: float = 60.0,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> None:
         resolved_cache = cache or LLMCache(max_size=256)
         super().__init__(
@@ -45,6 +52,8 @@ class GPTAgent(AIAgent):
         )
         self.api_key = api_key
         self.model = model
+        self.provider = provider.lower()
+        self.api_base = api_base
         self._rate_limiter = rate_limiter or RateLimiter(rate=60, per=60.0)
         self._cache = resolved_cache
         self._token_tracker = token_tracker or TokenUsageTracker()
@@ -52,6 +61,9 @@ class GPTAgent(AIAgent):
         self._max_retries = max_retries
         self._retry_backoff = retry_backoff
         self._logger = logging.getLogger(self.__class__.__name__)
+        self._max_output_tokens = max_output_tokens
+        self._request_timeout = request_timeout
+        self._extra_headers = dict(extra_headers or {})
 
     def _default_backend(self) -> LLMBackend:
         if not self.api_key:
@@ -59,7 +71,7 @@ class GPTAgent(AIAgent):
                 "No API key configured for GPTAgent. Provide `llm_backend` or set `api_key`."
             )
 
-        def _call_openai(prompt: str) -> str:
+        def _call_model(prompt: str) -> str:
             cached = self._cache_lookup(prompt)
             if cached is not None:
                 return cached
@@ -72,21 +84,15 @@ class GPTAgent(AIAgent):
                     self._rate_limiter.acquire()
                 start = perf_counter()
                 try:
-                    openai.api_key = self.api_key
-                    response = openai.ChatCompletion.create(
-                        model=self.model,
-                        messages=[{"role": "user", "content": prompt}],
-                        max_tokens=200,
-                    )
-                    content = response.choices[0].message["content"].strip()
+                    with self._response_time_tracker.track():
+                        content = self._invoke_provider(prompt)
                     duration = perf_counter() - start
+                    prompt_tokens = response_tokens = total_tokens = 0
                     if self._token_tracker is not None:
                         prompt_tokens, response_tokens = self._token_tracker.record(
                             prompt, content
                         )
                         total_tokens = prompt_tokens + response_tokens
-                    else:
-                        total_tokens = 0
                     if self._cost_tracker is not None and total_tokens:
                         self._cost_tracker.add_usage(self.model, total_tokens)
                     self._cache_store(prompt, content)
@@ -114,7 +120,132 @@ class GPTAgent(AIAgent):
                 raise BackendError("LLM call failed") from last_error
             raise BackendError("LLM call failed")
 
-        return _call_openai
+        return _call_model
+
+    # ------------------------------------------------------------------
+    # Provider specific implementations
+    # ------------------------------------------------------------------
+
+    def _invoke_provider(self, prompt: str) -> str:
+        if self.provider == "openai":
+            return self._invoke_openai(prompt)
+        if self.provider == "anthropic":
+            return self._invoke_anthropic(prompt)
+        if self.provider in {"gemini", "google", "google-gemini"}:
+            return self._invoke_gemini(prompt)
+        if self.provider in {"xai", "grok"}:
+            return self._invoke_grok(prompt)
+        raise ConfigurationError(f"Unsupported provider '{self.provider}'.")
+
+    def _invoke_openai(self, prompt: str) -> str:
+        openai.api_key = self.api_key
+        if self.api_base is not None:
+            openai.api_base = self.api_base
+        response = openai.ChatCompletion.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=self._max_output_tokens,
+            request_timeout=self._request_timeout,
+        )
+        content = response.choices[0].message["content"].strip()
+        if not content:
+            raise BackendError("Empty response from OpenAI provider.")
+        return content
+
+    def _invoke_anthropic(self, prompt: str) -> str:
+        try:
+            anthropic = importlib.import_module("anthropic")
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise ConfigurationError(
+                "Anthropic provider requires the 'anthropic' package to be installed."
+            ) from exc
+
+        client_cls = getattr(anthropic, "Anthropic", None)
+        if client_cls is None:  # pragma: no cover - defensive guard
+            raise ConfigurationError("Invalid anthropic client; update the 'anthropic' package.")
+
+        client_kwargs = {"api_key": self.api_key}
+        if self.api_base is not None:
+            client_kwargs["base_url"] = self.api_base
+        client = client_cls(**client_kwargs)
+        request: Dict[str, object] = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": self._max_output_tokens,
+        }
+        response = client.messages.create(**request)
+        content_blocks = getattr(response, "content", [])
+        if not content_blocks:
+            raise BackendError("Anthropic provider returned no content.")
+        parts = []
+        for block in content_blocks:
+            text = getattr(block, "text", None) or block.get("text") if isinstance(block, dict) else None
+            if text:
+                parts.append(text)
+        content = "".join(parts).strip()
+        if not content:
+            raise BackendError("Anthropic provider returned empty content.")
+        return content
+
+    def _invoke_gemini(self, prompt: str) -> str:
+        try:
+            generative_ai = importlib.import_module("google.generativeai")
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise ConfigurationError(
+                "Gemini provider requires the 'google-generativeai' package to be installed."
+            ) from exc
+
+        generative_ai.configure(api_key=self.api_key)
+        model = generative_ai.GenerativeModel(self.model)
+        response = model.generate_content(prompt)
+        if hasattr(response, "text") and response.text:
+            return response.text.strip()
+        candidates = getattr(response, "candidates", None)
+        if candidates:
+            for candidate in candidates:
+                content = getattr(candidate, "content", None)
+                if content and getattr(content, "parts", None):
+                    texts = [getattr(part, "text", "") for part in content.parts]
+                    joined = "".join(texts).strip()
+                    if joined:
+                        return joined
+        raise BackendError("Gemini provider returned empty content.")
+
+    def _invoke_grok(self, prompt: str) -> str:
+        url = self.api_base or "https://api.x.ai/v1/messages"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        headers.update(self._extra_headers)
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        response = requests.post(url, headers=headers, json=payload, timeout=self._request_timeout)
+        response.raise_for_status()
+        data = response.json()
+        message = data.get("message") or data.get("messages")
+        content: Optional[str] = None
+        if isinstance(message, list) and message:
+            message = message[-1]
+        if isinstance(message, dict):
+            content = message.get("content")
+        if isinstance(content, list):
+            parts = []
+            for item in content:
+                if isinstance(item, dict):
+                    text = item.get("text") or item.get("value")
+                    if text:
+                        parts.append(str(text))
+                elif isinstance(item, str):
+                    parts.append(item)
+            content = "".join(parts)
+        if not content:
+            content = data.get("content") or data.get("text")
+        if not content:
+            raise BackendError("Grok provider returned empty content.")
+        return str(content).strip()
 
     def respond(self, message: str) -> str:
         prompt = self.prepare_prompt(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,13 @@ packages = [{ include = "neva" }]
 [tool.poetry.dependencies]
 python = "^3.8"
 openai = "0.28.1"
+requests = "^2.31.0"
 wikipedia = { version = "1.4.0", optional = true }
 "deep-translator" = { version = "^1.11.4", optional = true }
 transformers = { version = "^4.35.2", optional = true }
 mlflow = { version = "^2.9.1", optional = true }
+anthropic = { version = "^0.26.0", optional = true }
+"google-generativeai" = { version = "^0.3.2", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 black = "23.9.1"
@@ -28,7 +31,15 @@ pytest = "7.4.2"
 [tool.poetry.extras]
 tools = ["wikipedia", "deep-translator", "transformers"]
 mlops = ["mlflow"]
-all = ["wikipedia", "deep-translator", "transformers", "mlflow"]
+providers = ["anthropic", "google-generativeai"]
+all = [
+    "wikipedia",
+    "deep-translator",
+    "transformers",
+    "mlflow",
+    "anthropic",
+    "google-generativeai",
+]
 
 [tool.black]
 line-length = 100

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,3 +2,5 @@ wikipedia==1.4.0
 deep-translator==1.11.4
 transformers==4.35.2
 mlflow==2.9.1
+anthropic==0.26.0
+google-generativeai==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 openai==0.28.1
+requests==2.31.0


### PR DESCRIPTION
## Summary
- extend `GPTAgent` with provider-aware backends for OpenAI, Anthropic Claude, Google Gemini, and xAI Grok
- expose configuration hooks for custom endpoints, headers, and token limits while keeping caching/metrics integration intact
- document the new options and add optional dependency extras for alternative LLM providers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ecec787d7c8323a2795f18ba4e493a