### PR TITLE
Add FAISS-backed vector memory integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ throughout the library, the quickstart script, and the accompanying tests.
 - **Flexible & Adaptable**: Adapt to various types of LLMs, tasks, and tools.
 - **Stateful Agents**: Built-in conversation state tracking and snapshot/restore
   helpers let you persist simulations mid-run and resume them later.
+- **Long-Term Memory Integrations**: Plug in semantic vector stores like FAISS
+  to give agents durable recall of historical conversations and research notes.
 - **Robust Safety Rails**: Prompt validation, sanitisation, rate limiting, and
   automatic retry logic keep API usage safe and predictable.
 - **Observability First**: Structured logging, response-time metrics, token and

--- a/neva/memory/__init__.py
+++ b/neva/memory/__init__.py
@@ -206,6 +206,131 @@ class VectorStoreMemory(MemoryModule):
         self._counter = 0
 
 
+class FaissVectorStoreMemory(MemoryModule):
+    """Long-term memory backed by a FAISS vector index for semantic recall."""
+
+    def __init__(
+        self,
+        embedder: Callable[[str], Sequence[float]],
+        *,
+        top_k: int = 5,
+        index_factory: str = "Flat",
+        normalize_embeddings: bool = True,
+        label: str = "faiss vector store",
+    ) -> None:
+        super().__init__(label=label)
+        if top_k <= 0:
+            raise MemoryConfigurationError("top_k must be positive")
+
+        try:  # Lazy import to keep dependency optional.
+            import faiss  # type: ignore
+        except ImportError as exc:  # pragma: no cover - exercised via tests when available.
+            raise MemoryConfigurationError(
+                "FaissVectorStoreMemory requires the 'faiss' package. "
+                "Install it with `pip install faiss-cpu`."
+            ) from exc
+
+        try:
+            import numpy as np
+        except ImportError as exc:  # pragma: no cover - numpy is required alongside faiss.
+            raise MemoryConfigurationError(
+                "FaissVectorStoreMemory requires NumPy alongside faiss."
+            ) from exc
+
+        self._faiss = faiss
+        self._np = np
+        self._embedder = embedder
+        self._top_k = top_k
+        self._index_factory = index_factory
+        self._normalize_embeddings = normalize_embeddings
+        self._base_index: Optional[faiss.Index] = None  # type: ignore[attr-defined]
+        self._index: Optional[faiss.Index] = None  # type: ignore[attr-defined]
+        self._records: Dict[int, MemoryRecord] = {}
+        self._order: List[int] = []
+        self._id_counter = 0
+
+    def _build_index(self, dimension: int) -> None:
+        self._base_index = self._faiss.index_factory(dimension, self._index_factory)
+        self._index = self._faiss.IndexIDMap(self._base_index)
+
+    def _encode(self, text: str) -> "np.ndarray":
+        vector = self._np.asarray(tuple(float(x) for x in self._embedder(text)), dtype="float32")
+        if vector.ndim != 1:
+            raise MemoryConfigurationError("Embeddings must be one-dimensional sequences of floats")
+        if self._normalize_embeddings:
+            self._faiss.normalize_L2(vector.reshape(1, -1))
+            vector = vector.reshape(-1)
+        return vector
+
+    def remember(
+        self, speaker: str, message: str, *, metadata: Optional[Dict[str, object]] = None
+    ) -> None:
+        text = f"{speaker}: {message}"
+        vector = self._encode(text)
+        if self._index is None:
+            self._build_index(vector.shape[0])
+        assert self._index is not None and self._base_index is not None  # for mypy type checking
+        record_id = self._id_counter
+        self._id_counter += 1
+        self._records[record_id] = MemoryRecord(
+            speaker=speaker,
+            message=message,
+            metadata=metadata,
+        )
+        self._order.append(record_id)
+        vector = vector.reshape(1, -1)
+        if not self._base_index.is_trained:
+            self._base_index.train(vector)
+        ids = self._np.asarray([record_id], dtype="int64")
+        self._index.add_with_ids(vector, ids)
+
+    def recall(
+        self,
+        *,
+        limit: Optional[int] = None,
+        query: Optional[str] = None,
+    ) -> str:
+        if not self._records:
+            return ""
+
+        limit = limit or self._top_k
+        limit = max(1, limit)
+
+        if not query:
+            record_ids = self._order[-limit:]
+            records = [self._records[rid] for rid in record_ids]
+            return "\n".join(f"{r.speaker}: {r.message}" for r in records)
+
+        if self._index is None:
+            return ""
+
+        query_vector = self._encode(query).reshape(1, -1)
+        k = min(limit, len(self._records))
+        scores, indices = self._index.search(query_vector, k)
+        results: List[Tuple[float, int, MemoryRecord]] = []
+        for score, idx in zip(scores[0], indices[0]):
+            if idx == -1:
+                continue
+            record = self._records.get(int(idx))
+            if record is None:
+                continue
+            results.append((float(score), int(idx), record))
+
+        if not results:
+            return ""
+
+        results.sort(key=lambda item: (item[0], -item[1]), reverse=True)
+        top_records = [record for _, _, record in results[:k]]
+        return "\n".join(f"{r.speaker}: {r.message}" for r in top_records)
+
+    def clear(self) -> None:
+        if self._index is not None:
+            self._index.reset()
+        self._records.clear()
+        self._order.clear()
+        self._id_counter = 0
+
+
 class CompositeMemory(MemoryModule):
     """Combine multiple memory modules and merge their recall outputs."""
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -4,3 +4,5 @@ transformers==4.35.2
 mlflow==2.9.1
 anthropic==0.26.0
 google-generativeai==0.3.2
+faiss-cpu==1.7.4
+numpy==1.26.4

--- a/tests/test_memory_faiss.py
+++ b/tests/test_memory_faiss.py
@@ -1,0 +1,51 @@
+import sys
+
+import pytest
+
+from neva.memory import FaissVectorStoreMemory, MemoryConfigurationError
+
+
+@pytest.fixture(scope="module")
+def _skip_if_faiss_missing():
+    pytest.importorskip("faiss")
+    pytest.importorskip("numpy")
+
+
+def _toy_embedder(text: str):
+    # Simple deterministic embedding based on character codes.
+    import numpy as np
+
+    vector = np.zeros(16, dtype="float32")
+    for index, byte in enumerate(text.encode("utf-8")):
+        vector[index % 16] += float(byte) / 255.0
+    return vector
+
+
+@pytest.mark.usefixtures("_skip_if_faiss_missing")
+def test_faiss_memory_recalls_similar_messages():
+    memory = FaissVectorStoreMemory(_toy_embedder, top_k=2)
+    memory.remember("Alice", "Discuss project timeline")
+    memory.remember("Bob", "Review architecture draft")
+    memory.remember("Alice", "Finalize project timeline")
+
+    summary = memory.recall(query="project timeline")
+    assert "Finalize project timeline" in summary
+    assert "Discuss project timeline" in summary
+    assert "architecture" not in summary
+
+
+def test_requires_faiss_dependency(monkeypatch):
+    if "faiss" in sys.modules:
+        pytest.skip("faiss installed; cannot test missing dependency")
+
+    original_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "faiss":
+            raise ImportError("missing")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    with pytest.raises(MemoryConfigurationError):
+        FaissVectorStoreMemory(_toy_embedder)


### PR DESCRIPTION
## Summary
- add a FAISS-backed vector store memory module for long-term semantic recall
- document the new memory integration and list its optional dependencies
- add regression tests covering FAISS recall behaviour and missing dependency handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed0808314883239ec3d4179c686b4e