### PR TITLE
Add standardized tool invocation interface for agents

### DIFF
--- a/neva/agents/__init__.py
+++ b/neva/agents/__init__.py
@@ -8,6 +8,8 @@ from .base import (
     LLMBackend,
     ParallelExecutionConfig,
     Tool,
+    ToolCall,
+    ToolResponse,
 )
 from .gpt import GPTAgent
 from .transformer import TransformerAgent
@@ -21,5 +23,7 @@ __all__ = [
     "LLMBackend",
     "ParallelExecutionConfig",
     "Tool",
+    "ToolCall",
+    "ToolResponse",
     "TransformerAgent",
 ]

--- a/neva/utils/exceptions.py
+++ b/neva/utils/exceptions.py
@@ -90,3 +90,7 @@ class ToolError(NevaError):
 class ToolExecutionError(ToolError):
     """Raised when a tool invocation fails."""
 
+
+class ToolNotFoundError(ToolError):
+    """Raised when attempting to use a tool that is not registered."""
+


### PR DESCRIPTION
## Summary
- introduce ToolCall and ToolResponse dataclasses so agents can standardize tool invocation metadata
- add agent helpers for resolving tools, normalizing arguments, and surfacing descriptive errors when a tool is missing
- expose new tool invocation API through package exports and cover behaviour with dedicated unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed09c256608323832a2365c26aa50c