### PR TITLE
feat: add adaptive conversation memory manager

### DIFF
--- a/neva/memory/__init__.py
+++ b/neva/memory/__init__.py
@@ -7,7 +7,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime
 from math import sqrt
-from typing import Callable, Deque, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Callable, Deque, Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple
 
 from neva.utils.exceptions import MemoryConfigurationError
 
@@ -362,4 +362,343 @@ class CompositeMemory(MemoryModule):
     def clear(self) -> None:
         for module in self._modules:
             module.clear()
+
+
+def _estimate_token_count(text: str) -> int:
+    """Rudimentary token estimator used for budgeting heuristics."""
+
+    if not text:
+        return 0
+    return max(1, len(text.split()))
+
+
+class MemoryBudget:
+    """Resource guard that bounds memory growth and embedding compute cost."""
+
+    def __init__(
+        self,
+        *,
+        max_records: Optional[int] = None,
+        max_tokens: Optional[int] = None,
+        max_embeddings: Optional[int] = None,
+        token_estimator: Callable[[str], int] = _estimate_token_count,
+    ) -> None:
+        if max_records is not None and max_records <= 0:
+            raise MemoryConfigurationError("max_records must be positive when provided")
+        if max_tokens is not None and max_tokens <= 0:
+            raise MemoryConfigurationError("max_tokens must be positive when provided")
+        if max_embeddings is not None and max_embeddings <= 0:
+            raise MemoryConfigurationError("max_embeddings must be positive when provided")
+
+        self.max_records = max_records
+        self.max_tokens = max_tokens
+        self.max_embeddings = max_embeddings
+        self._token_estimator = token_estimator
+        self._embedding_calls = 0
+
+    def token_count(self, message: str) -> int:
+        """Return the estimated token count for ``message``."""
+
+        return self._token_estimator(message)
+
+    def trim_history(
+        self,
+        history: List[Tuple[int, MemoryRecord]],
+        token_counts: Dict[int, int],
+    ) -> List[int]:
+        """Apply configured limits to ``history`` in-place.
+
+        Parameters
+        ----------
+        history:
+            Chronological list of ``(record_id, MemoryRecord)`` entries. Oldest
+            entries are trimmed first.
+        token_counts:
+            Mapping of ``record_id`` to the cached token estimation used for the
+            ``max_tokens`` constraint.
+
+        Returns
+        -------
+        List[int]
+            Identifiers for the records that were removed.
+        """
+
+        removed: List[int] = []
+
+        if self.max_records is not None:
+            while len(history) > self.max_records:
+                record_id, _ = history.pop(0)
+                removed.append(record_id)
+                token_counts.pop(record_id, None)
+
+        if self.max_tokens is not None:
+            def total_tokens() -> int:
+                return sum(token_counts[record_id] for record_id, _ in history)
+
+            while history and total_tokens() > self.max_tokens:
+                record_id, _ = history.pop(0)
+                removed.append(record_id)
+                token_counts.pop(record_id, None)
+
+        return removed
+
+    def can_embed(self) -> bool:
+        """Return ``True`` when another embedding call is permitted."""
+
+        return self.max_embeddings is None or self._embedding_calls < self.max_embeddings
+
+    def note_embedding(self) -> None:
+        """Record that an embedding has been computed."""
+
+        if self.max_embeddings is None:
+            return
+        self._embedding_calls += 1
+
+    def reset(self) -> None:
+        """Reset tracked compute usage counters."""
+
+        self._embedding_calls = 0
+
+
+class AdaptiveConversationMemory(MemoryModule):
+    """Hierarchical memory system that balances fidelity with resource usage.
+
+    The adaptive memory keeps a complete chronological history for exact replay
+    while exposing three specialised views:
+
+    - A short-term buffer that retains the most recent turns verbatim.
+    - A running summary that condenses the full dialogue.
+    - An optional semantic index for similarity search over the backlog.
+
+    A :class:`MemoryBudget` may be supplied to cap the amount of history stored
+    and the number of embeddings generated, enabling simulation-scale
+    deployments without unbounded growth.
+    """
+
+    def __init__(
+        self,
+        *,
+        summarizer: Callable[[str, MemoryRecord], str],
+        embedder: Optional[Callable[[str], Sequence[float]]] = None,
+        short_term_capacity: int = 6,
+        semantic_top_k: int = 3,
+        initial_summary: str = "",
+        budget: Optional[MemoryBudget] = None,
+        label: str = "adaptive memory",
+    ) -> None:
+        super().__init__(label=label)
+        if short_term_capacity <= 0:
+            raise MemoryConfigurationError("short_term_capacity must be positive")
+        if semantic_top_k <= 0:
+            raise MemoryConfigurationError("semantic_top_k must be positive")
+
+        self._summarizer = summarizer
+        self._embedder = embedder
+        self._short_term_capacity = short_term_capacity
+        self._semantic_top_k = semantic_top_k
+        self._initial_summary = initial_summary.strip()
+        self._budget = budget
+
+        self._history: List[Tuple[int, MemoryRecord]] = []
+        self._token_counts: Dict[int, int] = {}
+        self._semantic_entries: List[Tuple[int, MemoryRecord, Tuple[float, ...]]] = []
+        self._vector_cache: Dict[int, Tuple[float, ...]] = {}
+        self._id_counter = 0
+
+        self._short_term_label = "recent history"
+        self._summary_label = "summary"
+
+        self._short_term = ShortTermMemory(
+            capacity=short_term_capacity, label=self._short_term_label
+        )
+        self._summary = SummaryMemory(
+            summarizer,
+            initial_summary=initial_summary,
+            label=self._summary_label,
+        )
+
+    def remember(
+        self, speaker: str, message: str, *, metadata: Optional[Dict[str, object]] = None
+    ) -> None:
+        record = MemoryRecord(speaker=speaker, message=message, metadata=metadata)
+        record_id = self._id_counter
+        self._id_counter += 1
+
+        self._history.append((record_id, record))
+
+        if self._budget is not None:
+            self._token_counts[record_id] = self._budget.token_count(record.message)
+        else:
+            self._token_counts[record_id] = _estimate_token_count(record.message)
+
+        self._short_term.remember(speaker, message, metadata=metadata)
+        self._summary.remember(speaker, message, metadata=metadata)
+
+        self._maybe_store_semantic(record_id, record)
+
+        removed_ids = self._enforce_budget()
+        if removed_ids:
+            self._rebuild_views()
+
+    def recall(
+        self,
+        *,
+        limit: Optional[int] = None,
+        query: Optional[str] = None,
+    ) -> str:
+        sections: List[Tuple[str, str]] = []
+
+        if query:
+            recent = self._short_term.recall(limit=limit, query=query)
+            if recent:
+                sections.append(("recent", recent))
+
+            semantic = self._semantic_search(query, limit)
+            if semantic:
+                sections.append(("semantic", semantic))
+
+            summary = self._summary.recall(query=query)
+            if summary:
+                sections.append(("summary", summary))
+        else:
+            recent = self._short_term.recall(limit=limit)
+            if recent:
+                sections.append(("recent", recent))
+
+            summary = self._summary.recall()
+            if summary:
+                sections.append(("summary", summary))
+
+        unique_sections = []
+        seen_snippets: Set[str] = set()
+        for label, text in sections:
+            if text and text not in seen_snippets:
+                unique_sections.append((label, text))
+                seen_snippets.add(text)
+
+        if not unique_sections:
+            return ""
+
+        return "\n\n".join(f"{label}:\n{text}" for label, text in unique_sections)
+
+    def clear(self) -> None:
+        self._history.clear()
+        self._token_counts.clear()
+        self._semantic_entries.clear()
+        self._vector_cache.clear()
+        self._id_counter = 0
+        self._short_term = ShortTermMemory(
+            capacity=self._short_term_capacity, label=self._short_term_label
+        )
+        self._summary = SummaryMemory(
+            self._summarizer,
+            initial_summary=self._initial_summary,
+            label=self._summary_label,
+        )
+        if self._budget is not None:
+            self._budget.reset()
+
+    def iter_history(self, *, speaker: Optional[str] = None) -> Iterator[MemoryRecord]:
+        """Yield historical records optionally filtered by ``speaker``."""
+
+        for _, record in self._history:
+            if speaker is None or record.speaker == speaker:
+                yield record
+
+    def recent_window(
+        self, size: int, *, speaker: Optional[str] = None
+    ) -> List[MemoryRecord]:
+        """Return the most recent ``size`` records, optionally filtered."""
+
+        if size <= 0:
+            return []
+        filtered = list(self.iter_history(speaker=speaker))
+        if not filtered:
+            return []
+        return filtered[-size:]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _maybe_store_semantic(
+        self, record_id: int, record: MemoryRecord
+    ) -> None:
+        if self._embedder is None:
+            return
+
+        if record_id in self._vector_cache:
+            vector = self._vector_cache[record_id]
+        else:
+            if self._budget is not None and not self._budget.can_embed():
+                return
+            text = f"{record.speaker}: {record.message}"
+            vector = tuple(float(x) for x in self._embedder(text))
+            self._vector_cache[record_id] = vector
+            if self._budget is not None:
+                self._budget.note_embedding()
+
+        self._semantic_entries.append((record_id, record, vector))
+
+    def _enforce_budget(self) -> List[int]:
+        if self._budget is None:
+            return []
+
+        removed_ids = self._budget.trim_history(self._history, self._token_counts)
+        if not removed_ids:
+            return []
+
+        for record_id in removed_ids:
+            self._vector_cache.pop(record_id, None)
+
+        self._semantic_entries = [
+            (record_id, record, vector)
+            for record_id, record, vector in self._semantic_entries
+            if record_id not in removed_ids
+        ]
+
+        return removed_ids
+
+    def _rebuild_views(self) -> None:
+        self._short_term = ShortTermMemory(
+            capacity=self._short_term_capacity, label=self._short_term_label
+        )
+        self._summary = SummaryMemory(
+            self._summarizer,
+            initial_summary=self._initial_summary,
+            label=self._summary_label,
+        )
+
+        for record_id, record in self._history:
+            self._short_term.remember(record.speaker, record.message, metadata=record.metadata)
+            self._summary.remember(record.speaker, record.message, metadata=record.metadata)
+
+        self._semantic_entries = []
+        for record_id, record in self._history:
+            vector = self._vector_cache.get(record_id)
+            if vector is None:
+                continue
+            self._semantic_entries.append((record_id, record, vector))
+
+    def _semantic_search(self, query: str, limit: Optional[int]) -> str:
+        if self._embedder is None or not self._semantic_entries:
+            return ""
+
+        query_vector = tuple(float(x) for x in self._embedder(query))
+        size = limit or self._semantic_top_k
+        size = max(1, size)
+
+        scored = [
+            (record_id, record, _cosine_similarity(vector, query_vector))
+            for record_id, record, vector in self._semantic_entries
+        ]
+
+        scored = [item for item in scored if item[2] > 0]
+        scored.sort(key=lambda item: (item[2], item[0]), reverse=True)
+
+        top_records = [record for _, record, _score in scored[:size]]
+        if not top_records:
+            return ""
+
+        return "\n".join(f"{record.speaker}: {record.message}" for record in top_records)
+
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,10 +1,12 @@
-from typing import List
+from typing import List, Sequence
 
 import pytest
 
 from neva.agents import AIAgent
 from neva.memory import (
+    AdaptiveConversationMemory,
     CompositeMemory,
+    MemoryBudget,
     MemoryRecord,
     ShortTermMemory,
     SummaryMemory,
@@ -105,3 +107,75 @@ def test_memory_invalid_configurations_raise():
 
     with pytest.raises(MemoryConfigurationError):
         CompositeMemory([])
+
+
+def _adaptive_summariser(summary: str, record: MemoryRecord) -> str:
+    snippet = f"{record.speaker} -> {record.message}"
+    return f"{summary}; {snippet}" if summary else snippet
+
+
+def _vowel_embedder(text: str) -> Sequence[float]:
+    lowered = text.lower()
+    return [float(lowered.count(ch)) for ch in "aeiou"]
+
+
+def test_adaptive_memory_combines_views():
+    memory = AdaptiveConversationMemory(
+        summarizer=_adaptive_summariser,
+        embedder=_vowel_embedder,
+        short_term_capacity=2,
+        semantic_top_k=2,
+    )
+
+    memory.remember("user", "Discuss launch plan")
+    memory.remember("agent", "Draft proposal outline")
+    memory.remember("user", "Review launch checklist")
+    memory.remember("agent", "Finalize launch plan")
+
+    combined = memory.recall()
+    assert "recent:\nuser: Review launch checklist" in combined
+    assert "summary:\nuser -> Discuss launch plan" in combined
+
+    semantic = memory.recall(query="launch plan")
+    assert "semantic:\n" in semantic
+    assert "agent: Finalize launch plan" in semantic
+
+
+def test_adaptive_memory_budget_trims_history():
+    budget = MemoryBudget(max_records=3, max_tokens=20)
+    memory = AdaptiveConversationMemory(
+        summarizer=_adaptive_summariser,
+        short_term_capacity=5,
+        budget=budget,
+    )
+
+    for idx in range(6):
+        memory.remember("user", f"turn-{idx}")
+
+    remaining = [record.message for record in memory.iter_history()]
+    assert remaining == ["turn-3", "turn-4", "turn-5"]
+
+    window = memory.recent_window(2)
+    assert [record.message for record in window] == ["turn-4", "turn-5"]
+
+
+def test_memory_budget_limits_embedding_calls():
+    embed_calls = 0
+
+    def embed(text: str) -> Sequence[float]:
+        nonlocal embed_calls
+        embed_calls += 1
+        return [float(len(text))]
+
+    budget = MemoryBudget(max_embeddings=2)
+    memory = AdaptiveConversationMemory(
+        summarizer=_adaptive_summariser,
+        embedder=embed,
+        budget=budget,
+    )
+
+    for idx in range(5):
+        memory.remember("user", f"item-{idx}")
+
+    assert embed_calls == 2
+


### PR DESCRIPTION
## Summary
- add a MemoryBudget helper to constrain record, token, and embedding usage in conversation memories
- introduce AdaptiveConversationMemory for combining short-term, summary, and semantic recall with budget enforcement
- extend memory tests to cover adaptive recall behaviour and resource limits

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ed0e14dfe4832396fd5cc9f949e4a7