### PR TITLE
Add pluggable scheduler registry and new scheduling strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,34 @@ metrics via the observer system, and invokes the agent's `respond` method with
 the current environmental context. This mirrors the simulation lifecycle used
 throughout the library, the quickstart script, and the accompanying tests.
 
+### Built-in scheduling strategies
+
+Neva ships with a pluggable scheduler registry (`neva.schedulers.register_scheduler`)
+and a suite of ready-to-use strategies:
+
+* `RoundRobinScheduler` – cycle through agents in a fixed order.
+* `RandomScheduler` – pick an available agent at random.
+* `PriorityScheduler` – prefer agents with higher priority values.
+* `LeastRecentlyUsedScheduler` – activate the agent that has waited the longest.
+* `WeightedRandomScheduler` – random sampling with configurable weights.
+* `EventDrivenScheduler` – run agents when they emit events.
+* `ConditionalScheduler` – run agents only when a predicate on their state is met.
+* `CompositeScheduler` – nest schedulers to manage agent sub-groups.
+
+Custom schedulers can be registered at runtime:
+
+```python
+from neva.schedulers import register_scheduler, create_scheduler, Scheduler
+
+
+class MyScheduler(Scheduler):
+    ...
+
+
+register_scheduler("my_scheduler", MyScheduler)
+scheduler = create_scheduler("my_scheduler")
+```
+
 ## Features
 - **Flexible & Adaptable**: Adapt to various types of LLMs, tasks, and tools.
 - **Stateful Agents**: Built-in conversation state tracking and snapshot/restore

--- a/neva/schedulers/__init__.py
+++ b/neva/schedulers/__init__.py
@@ -2,261 +2,134 @@
 
 from __future__ import annotations
 
-import random
-from typing import Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Dict, Iterable, List, Optional, Type, TypeVar
 
-from neva.agents.base import AIAgent
-from neva.utils.exceptions import ConfigurationError, SchedulingError
-from neva.utils.observer import SimulationObserver
+from neva.utils.exceptions import ConfigurationError
 
 from .base import Scheduler
+from .composite import CompositeScheduler
+from .conditional import ConditionalScheduler
+from .event_driven import EventDrivenScheduler
+from .least_recently_used import LeastRecentlyUsedScheduler
+from .priority import PriorityScheduler
+from .random import RandomScheduler
 from .round_robin import RoundRobinScheduler
+from .weighted_random import WeightedRandomScheduler
 
-if TYPE_CHECKING:  # pragma: no cover - import used only for typing.
-    from neva.environments.base import Environment
+SchedulerType = TypeVar("SchedulerType", bound=Scheduler)
 
-
-class RandomScheduler(Scheduler):
-    """Activate agents in a random order each step."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.simulation_observer = SimulationObserver()
-
-    def add(self, agent: AIAgent, **_: object) -> None:
-        if agent not in self.agents:
-            self.agents.append(agent)
-
-    def get_next_agent(self) -> AIAgent:
-        active_agents = self._active_agents()
-        if not active_agents:
-            raise SchedulingError("RandomScheduler has no active agents to schedule.")
-        agent = random.choice(active_agents)
-        self.record_metrics(agent)
-        return agent
+_REGISTRY: Dict[str, Type[Scheduler]] = {}
+_ALIASES: Dict[str, str] = {}
 
 
-class PriorityScheduler(Scheduler):
-    """Activate agents based on their priority (higher first)."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.simulation_observer = SimulationObserver()
-        self._queue: List[Tuple[int, AIAgent]] = []
-
-    def add(self, agent: AIAgent, **kwargs: object) -> None:
-        priority = kwargs.get("priority", 1)
-        self._queue.append((priority, agent))
-        if agent not in self.agents:
-            self.agents.append(agent)
-
-    def get_next_agent(self) -> AIAgent:
-        if not self._queue:
-            raise SchedulingError("PriorityScheduler has no agents to schedule.")
-
-        self._queue.sort(reverse=True)
-        for _ in range(len(self._queue)):
-            priority, agent = self._queue.pop(0)
-            self._queue.append((priority, agent))
-            if self.is_paused(agent):
-                continue
-            self.record_metrics(agent)
-            return agent
-
-        raise SchedulingError("PriorityScheduler has no active agents to schedule.")
-
-    def _handle_agent_removal(self, agent: AIAgent) -> None:
-        self._queue = [
-            (priority, queued) for priority, queued in self._queue if queued is not agent
-        ]
+def _canonical_name(name: str) -> str:
+    if not name or not name.strip():
+        raise ConfigurationError("Scheduler name cannot be empty.")
+    return name.strip().lower()
 
 
-class LeastRecentlyUsedScheduler(Scheduler):
-    """Activate the agent that has waited the longest."""
+def _resolve_to_canonical(name: str) -> str:
+    key = name.strip()
+    if not key:
+        raise ConfigurationError("Scheduler name cannot be empty.")
 
-    def __init__(self) -> None:
-        super().__init__()
-        self.simulation_observer = SimulationObserver()
-        self._queue: List[AIAgent] = []
+    canonical = key.lower()
+    if canonical in _REGISTRY:
+        return canonical
 
-    def add(self, agent: AIAgent, **_: object) -> None:
-        if agent not in self.agents:
-            self.agents.append(agent)
-            self._queue.append(agent)
-        elif agent not in self._queue:
-            self._queue.append(agent)
+    alias_target = _ALIASES.get(key) or _ALIASES.get(canonical)
+    if alias_target is not None and alias_target in _REGISTRY:
+        return alias_target
 
-    def get_next_agent(self) -> AIAgent:
-        if not self._queue:
-            raise SchedulingError("LeastRecentlyUsedScheduler has no agents to schedule.")
-
-        total_considered = len(self._queue)
-        for _ in range(total_considered):
-            agent = self._queue.pop(0)
-            self._queue.append(agent)
-            if self.is_paused(agent):
-                continue
-            self.record_metrics(agent)
-            return agent
-
-        raise SchedulingError("LeastRecentlyUsedScheduler has no active agents to schedule.")
-
-    def _handle_agent_removal(self, agent: AIAgent) -> None:
-        self._queue = [queued for queued in self._queue if queued is not agent]
+    available = ", ".join(sorted(_REGISTRY)) or "<none>"
+    raise ConfigurationError(
+        f"Unknown scheduler '{name}'. Available schedulers: {available}."
+    )
 
 
-class WeightedRandomScheduler(Scheduler):
-    """Activate agents randomly according to provided weights."""
+def register_scheduler(
+    name: str,
+    scheduler_cls: Type[SchedulerType],
+    *,
+    overwrite: bool = False,
+    aliases: Optional[Iterable[str]] = None,
+) -> None:
+    """Register ``scheduler_cls`` under ``name`` and optional aliases."""
 
-    def __init__(self) -> None:
-        super().__init__()
-        self.simulation_observer = SimulationObserver()
-        self._entries: List[Tuple[float, AIAgent]] = []
+    if not issubclass(scheduler_cls, Scheduler):
+        raise ConfigurationError("scheduler_cls must inherit from Scheduler")
 
-    def add(self, agent: AIAgent, **kwargs: object) -> None:
-        weight = float(kwargs.get("weight", 1.0))
-        self._entries.append((weight, agent))
-        if agent not in self.agents:
-            self.agents.append(agent)
-
-    def get_next_agent(self) -> AIAgent:
-        if not self._entries:
-            raise SchedulingError("WeightedRandomScheduler has no agents to schedule.")
-
-        active_entries = [
-            (weight, agent) for weight, agent in self._entries if not self.is_paused(agent)
-        ]
-        if not active_entries:
-            raise SchedulingError(
-                "WeightedRandomScheduler has no active agents to schedule."
-            )
-
-        total_weight = sum(weight for weight, _ in active_entries)
-        random_weight = random.uniform(0, total_weight)
-        for weight, agent in active_entries:
-            if random_weight <= weight:
-                self.record_metrics(agent)
-                return agent
-            random_weight -= weight
-
-        agent = active_entries[-1][1]
-        self.record_metrics(agent)
-        return agent
-
-    def _handle_agent_removal(self, agent: AIAgent) -> None:
-        self._entries = [
-            (weight, queued) for weight, queued in self._entries if queued is not agent
-        ]
-
-
-class CompositeScheduler(Scheduler):
-    """Coordinate multiple sub-schedulers managing agent sub-groups."""
-
-    def __init__(self, group_scheduler_factory: Optional[Callable[[], Scheduler]] = None) -> None:
-        super().__init__()
-        self.simulation_observer = SimulationObserver()
-        self._group_scheduler_factory: Callable[[], Scheduler] = (
-            group_scheduler_factory or RoundRobinScheduler
+    canonical = _canonical_name(name)
+    existing = _REGISTRY.get(canonical)
+    if existing is not None and existing is not scheduler_cls and not overwrite:
+        raise ConfigurationError(
+            f"Scheduler '{canonical}' already registered with {existing.__name__}."
         )
-        self._group_schedulers: Dict[str, Scheduler] = {}
-        self._group_membership: Dict[AIAgent, str] = {}
-        self._group_order: List[str] = []
-        self._group_index = 0
 
-    def set_environment(self, environment: "Environment") -> None:
-        super().set_environment(environment)
-        for scheduler in self._group_schedulers.values():
-            scheduler.set_environment(environment)
+    _REGISTRY[canonical] = scheduler_cls
 
-    def add(self, agent: AIAgent, **kwargs: object) -> None:
-        group = kwargs.pop("group", "default")
-        scheduler_override = kwargs.pop("scheduler", None)
+    for alias in {name, scheduler_cls.__name__} | set(aliases or []):
+        alias_key = alias.strip()
+        if not alias_key:
+            continue
+        _ALIASES[alias_key] = canonical
+        _ALIASES[alias_key.lower()] = canonical
 
-        existing_group = self._group_membership.get(agent)
-        if existing_group is not None and existing_group != group:
-            self._detach_agent_from_group(agent, existing_group)
 
-        group_scheduler = self._ensure_group_scheduler(group, scheduler_override)
+def unregister_scheduler(name: str) -> None:
+    """Remove ``name`` and its aliases from the registry."""
 
-        if agent not in self.agents:
-            self.agents.append(agent)
-        if agent not in group_scheduler.agents:
-            group_scheduler.add(agent, **kwargs)
-        self._group_membership[agent] = group
+    canonical = _resolve_to_canonical(name)
+    _REGISTRY.pop(canonical, None)
+    for alias, target in list(_ALIASES.items()):
+        if target == canonical:
+            _ALIASES.pop(alias)
 
-        if group not in self._group_order:
-            self._group_order.append(group)
 
-    def get_next_agent(self) -> AIAgent:
-        if not self._group_order:
-            raise SchedulingError("CompositeScheduler has no groups to schedule.")
+def get_scheduler_class(name: str) -> Type[SchedulerType]:
+    """Return the registered scheduler class for ``name``."""
 
-        total_groups = len(self._group_order)
-        for _ in range(total_groups):
-            group = self._group_order[self._group_index]
-            self._group_index = (self._group_index + 1) % total_groups
-            scheduler = self._group_schedulers[group]
-            try:
-                agent = scheduler.get_next_agent()
-            except SchedulingError:
-                continue
-            if self.is_paused(agent):
-                scheduler.pause(agent)
-                continue
-            self.record_metrics(agent)
-            return agent
+    canonical = _resolve_to_canonical(name)
+    return _REGISTRY[canonical]
 
-        raise SchedulingError("CompositeScheduler has no active agents to schedule.")
 
-    def _ensure_group_scheduler(
-        self, group: str, scheduler_override: Optional[Scheduler]
-    ) -> Scheduler:
-        if group not in self._group_schedulers:
-            scheduler = scheduler_override or self._group_scheduler_factory()
-            self._validate_scheduler(scheduler)
-            self._group_schedulers[group] = scheduler
-            if self.environment is not None:
-                scheduler.set_environment(self.environment)
-        return self._group_schedulers[group]
+def create_scheduler(name: str, **kwargs: object) -> Scheduler:
+    """Instantiate the scheduler associated with ``name``."""
 
-    def _detach_agent_from_group(self, agent: AIAgent, group: str) -> None:
-        scheduler = self._group_schedulers.get(group)
-        if scheduler is None:
-            return
-        scheduler.terminate(agent)
-        self._group_membership.pop(agent, None)
-        if not scheduler.agents:
-            self._group_schedulers.pop(group, None)
-            self._group_order = [existing for existing in self._group_order if existing != group]
-            if self._group_index >= len(self._group_order) and self._group_order:
-                self._group_index %= len(self._group_order)
+    scheduler_cls = get_scheduler_class(name)
+    return scheduler_cls(**kwargs)
 
-    def _handle_agent_removal(self, agent: AIAgent) -> None:
-        group = self._group_membership.pop(agent, None)
-        if group is None:
-            return
-        scheduler = self._group_schedulers.get(group)
-        if scheduler is None:
-            return
-        scheduler.terminate(agent)
-        if not scheduler.agents:
-            self._group_schedulers.pop(group, None)
-            self._group_order = [existing for existing in self._group_order if existing != group]
-            if self._group_index >= len(self._group_order) and self._group_order:
-                self._group_index %= len(self._group_order)
 
-    @staticmethod
-    def _validate_scheduler(scheduler: Scheduler) -> None:
-        if not isinstance(scheduler, Scheduler):
-            raise ConfigurationError("Provided scheduler must be an instance of Scheduler")
+def available_schedulers() -> List[str]:
+    """Return the sorted list of registered scheduler names."""
+
+    return sorted(_REGISTRY)
+
+
+# Register built-in schedulers.
+register_scheduler("round_robin", RoundRobinScheduler)
+register_scheduler("random", RandomScheduler)
+register_scheduler("priority", PriorityScheduler)
+register_scheduler("least_recently_used", LeastRecentlyUsedScheduler)
+register_scheduler("weighted_random", WeightedRandomScheduler)
+register_scheduler("composite", CompositeScheduler)
+register_scheduler("event_driven", EventDrivenScheduler)
+register_scheduler("conditional", ConditionalScheduler)
 
 
 __all__ = [
     "CompositeScheduler",
+    "ConditionalScheduler",
+    "EventDrivenScheduler",
     "LeastRecentlyUsedScheduler",
     "PriorityScheduler",
     "RandomScheduler",
     "RoundRobinScheduler",
     "Scheduler",
     "WeightedRandomScheduler",
+    "available_schedulers",
+    "create_scheduler",
+    "get_scheduler_class",
+    "register_scheduler",
+    "unregister_scheduler",
 ]

--- a/neva/schedulers/composite.py
+++ b/neva/schedulers/composite.py
@@ -1,0 +1,121 @@
+"""Composite scheduler implementation."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Optional
+
+from neva.agents.base import AIAgent
+from neva.schedulers.base import Scheduler
+from neva.schedulers.round_robin import RoundRobinScheduler
+from neva.utils.exceptions import ConfigurationError, SchedulingError
+from neva.utils.observer import SimulationObserver
+
+if False:  # pragma: no cover - for type checking only
+    from neva.environments.base import Environment
+
+
+class CompositeScheduler(Scheduler):
+    """Coordinate multiple sub-schedulers managing agent sub-groups."""
+
+    def __init__(
+        self, group_scheduler_factory: Optional[Callable[[], Scheduler]] = None
+    ) -> None:
+        super().__init__()
+        self.simulation_observer = SimulationObserver()
+        self._group_scheduler_factory: Callable[[], Scheduler] = (
+            group_scheduler_factory or RoundRobinScheduler
+        )
+        self._group_schedulers: Dict[str, Scheduler] = {}
+        self._group_membership: Dict[AIAgent, str] = {}
+        self._group_order: List[str] = []
+        self._group_index = 0
+
+    def set_environment(self, environment: "Environment") -> None:
+        super().set_environment(environment)
+        for scheduler in self._group_schedulers.values():
+            scheduler.set_environment(environment)
+
+    def add(self, agent: AIAgent, **kwargs: object) -> None:
+        group = kwargs.pop("group", "default")
+        scheduler_override = kwargs.pop("scheduler", None)
+
+        existing_group = self._group_membership.get(agent)
+        if existing_group is not None and existing_group != group:
+            self._detach_agent_from_group(agent, existing_group)
+
+        group_scheduler = self._ensure_group_scheduler(group, scheduler_override)
+
+        if agent not in self.agents:
+            self.agents.append(agent)
+        if agent not in group_scheduler.agents:
+            group_scheduler.add(agent, **kwargs)
+        self._group_membership[agent] = group
+
+        if group not in self._group_order:
+            self._group_order.append(group)
+
+    def get_next_agent(self) -> AIAgent:
+        if not self._group_order:
+            raise SchedulingError("CompositeScheduler has no groups to schedule.")
+
+        total_groups = len(self._group_order)
+        for _ in range(total_groups):
+            group = self._group_order[self._group_index]
+            self._group_index = (self._group_index + 1) % total_groups
+            scheduler = self._group_schedulers[group]
+            try:
+                agent = scheduler.get_next_agent()
+            except SchedulingError:
+                continue
+            if self.is_paused(agent):
+                scheduler.pause(agent)
+                continue
+            self.record_metrics(agent)
+            return agent
+
+        raise SchedulingError("CompositeScheduler has no active agents to schedule.")
+
+    def _ensure_group_scheduler(
+        self, group: str, scheduler_override: Optional[Scheduler]
+    ) -> Scheduler:
+        if group not in self._group_schedulers:
+            scheduler = scheduler_override or self._group_scheduler_factory()
+            self._validate_scheduler(scheduler)
+            self._group_schedulers[group] = scheduler
+            if self.environment is not None:
+                scheduler.set_environment(self.environment)
+        return self._group_schedulers[group]
+
+    def _detach_agent_from_group(self, agent: AIAgent, group: str) -> None:
+        scheduler = self._group_schedulers.get(group)
+        if scheduler is None:
+            return
+        scheduler.terminate(agent)
+        self._group_membership.pop(agent, None)
+        if not scheduler.agents:
+            self._group_schedulers.pop(group, None)
+            self._group_order = [existing for existing in self._group_order if existing != group]
+            if self._group_index >= len(self._group_order) and self._group_order:
+                self._group_index %= len(self._group_order)
+
+    def _handle_agent_removal(self, agent: AIAgent) -> None:
+        group = self._group_membership.pop(agent, None)
+        if group is None:
+            return
+        scheduler = self._group_schedulers.get(group)
+        if scheduler is None:
+            return
+        scheduler.terminate(agent)
+        if not scheduler.agents:
+            self._group_schedulers.pop(group, None)
+            self._group_order = [existing for existing in self._group_order if existing != group]
+            if self._group_index >= len(self._group_order) and self._group_order:
+                self._group_index %= len(self._group_order)
+
+    @staticmethod
+    def _validate_scheduler(scheduler: Scheduler) -> None:
+        if not isinstance(scheduler, Scheduler):
+            raise ConfigurationError("Provided scheduler must be an instance of Scheduler")
+
+
+__all__ = ["CompositeScheduler"]

--- a/neva/schedulers/conditional.py
+++ b/neva/schedulers/conditional.py
@@ -1,0 +1,76 @@
+"""Conditional scheduler implementation."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, cast
+
+from neva.agents.base import AIAgent
+from neva.schedulers.base import Scheduler
+from neva.utils.exceptions import ConfigurationError, SchedulingError
+from neva.utils.observer import SimulationObserver
+
+
+Condition = Callable[[AIAgent], bool]
+
+
+class ConditionalScheduler(Scheduler):
+    """Activate agents only when associated conditions evaluate to ``True``."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.simulation_observer = SimulationObserver()
+        self._conditions: Dict[AIAgent, Condition] = {}
+        self._current_index = 0
+
+    def add(self, agent: AIAgent, **kwargs: object) -> None:
+        condition = kwargs.get("condition") or kwargs.get("predicate")
+        if condition is None:
+            condition = lambda _: True
+        if not callable(condition):
+            raise ConfigurationError("ConditionalScheduler requires a callable condition.")
+
+        self._conditions[agent] = cast(Condition, condition)
+        if agent not in self.agents:
+            self.agents.append(agent)
+
+    def set_condition(self, agent: AIAgent, condition: Condition) -> None:
+        """Update the condition controlling when ``agent`` can execute."""
+
+        if not callable(condition):
+            raise ConfigurationError("ConditionalScheduler requires a callable condition.")
+        if agent not in self.agents:
+            raise ConfigurationError("Agent must be registered before assigning a condition.")
+        self._conditions[agent] = cast(Condition, condition)
+
+    def get_next_agent(self) -> AIAgent:
+        if not self.agents:
+            raise SchedulingError("ConditionalScheduler has no agents to schedule.")
+
+        total_agents = len(self.agents)
+        for _ in range(total_agents):
+            agent = self.agents[self._current_index]
+            self._current_index = (self._current_index + 1) % total_agents
+            if self.is_paused(agent):
+                continue
+
+            condition = self._conditions.get(agent)
+            try:
+                allowed = condition(agent) if condition is not None else True
+            except Exception as exc:  # pragma: no cover - defensive guard
+                raise SchedulingError("Condition callable raised an exception") from exc
+
+            if allowed:
+                self.record_metrics(agent)
+                return agent
+
+        raise SchedulingError("ConditionalScheduler has no agents meeting their condition.")
+
+    def _handle_agent_removal(self, agent: AIAgent) -> None:
+        self._conditions.pop(agent, None)
+        if self.agents:
+            self._current_index %= len(self.agents)
+        else:
+            self._current_index = 0
+
+
+__all__ = ["ConditionalScheduler"]

--- a/neva/schedulers/event_driven.py
+++ b/neva/schedulers/event_driven.py
@@ -1,0 +1,50 @@
+"""Event-driven scheduler implementation."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque
+
+from neva.agents.base import AIAgent
+from neva.schedulers.base import Scheduler
+from neva.utils.exceptions import SchedulingError
+from neva.utils.observer import SimulationObserver
+
+
+class EventDrivenScheduler(Scheduler):
+    """Only activate agents that have published an event signal."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.simulation_observer = SimulationObserver()
+        self._event_queue: Deque[AIAgent] = deque()
+
+    def add(self, agent: AIAgent, **_: object) -> None:
+        if agent not in self.agents:
+            self.agents.append(agent)
+
+    def notify_event(self, agent: AIAgent) -> None:
+        """Register an event for ``agent`` so it becomes eligible for execution."""
+
+        if agent not in self.agents or agent in self._event_queue:
+            return
+        self._event_queue.append(agent)
+
+    def get_next_agent(self) -> AIAgent:
+        while self._event_queue:
+            agent = self._event_queue.popleft()
+            if agent not in self.agents:
+                continue
+            if self.is_paused(agent):
+                self._event_queue.append(agent)
+                continue
+            self.record_metrics(agent)
+            return agent
+
+        raise SchedulingError("EventDrivenScheduler has no pending events to schedule.")
+
+    def _handle_agent_removal(self, agent: AIAgent) -> None:
+        self._event_queue = deque(existing for existing in self._event_queue if existing is not agent)
+
+
+__all__ = ["EventDrivenScheduler"]

--- a/neva/schedulers/least_recently_used.py
+++ b/neva/schedulers/least_recently_used.py
@@ -1,0 +1,51 @@
+"""Least Recently Used (LRU) scheduler implementation."""
+
+from __future__ import annotations
+
+from typing import List
+
+from neva.agents.base import AIAgent
+from neva.schedulers.base import Scheduler
+from neva.utils.exceptions import SchedulingError
+from neva.utils.observer import SimulationObserver
+
+
+class LeastRecentlyUsedScheduler(Scheduler):
+    """Activate the agent that has waited the longest since last execution."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.simulation_observer = SimulationObserver()
+        self._queue: List[AIAgent] = []
+
+    def add(self, agent: AIAgent, **_: object) -> None:
+        if agent not in self.agents:
+            self.agents.append(agent)
+            self._queue.append(agent)
+        elif agent not in self._queue:
+            self._queue.append(agent)
+
+    def get_next_agent(self) -> AIAgent:
+        if not self._queue:
+            raise SchedulingError(
+                "LeastRecentlyUsedScheduler has no agents to schedule."
+            )
+
+        total_considered = len(self._queue)
+        for _ in range(total_considered):
+            agent = self._queue.pop(0)
+            self._queue.append(agent)
+            if self.is_paused(agent):
+                continue
+            self.record_metrics(agent)
+            return agent
+
+        raise SchedulingError(
+            "LeastRecentlyUsedScheduler has no active agents to schedule."
+        )
+
+    def _handle_agent_removal(self, agent: AIAgent) -> None:
+        self._queue = [queued for queued in self._queue if queued is not agent]
+
+
+__all__ = ["LeastRecentlyUsedScheduler"]

--- a/neva/schedulers/priority.py
+++ b/neva/schedulers/priority.py
@@ -1,0 +1,48 @@
+"""Priority-based scheduler implementation."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from neva.agents.base import AIAgent
+from neva.schedulers.base import Scheduler
+from neva.utils.exceptions import SchedulingError
+from neva.utils.observer import SimulationObserver
+
+
+class PriorityScheduler(Scheduler):
+    """Activate agents based on priority (higher values run first)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.simulation_observer = SimulationObserver()
+        self._queue: List[Tuple[int, AIAgent]] = []
+
+    def add(self, agent: AIAgent, **kwargs: object) -> None:
+        priority = int(kwargs.get("priority", 1))
+        self._queue.append((priority, agent))
+        if agent not in self.agents:
+            self.agents.append(agent)
+
+    def get_next_agent(self) -> AIAgent:
+        if not self._queue:
+            raise SchedulingError("PriorityScheduler has no agents to schedule.")
+
+        self._queue.sort(key=lambda item: item[0], reverse=True)
+        for _ in range(len(self._queue)):
+            priority, agent = self._queue.pop(0)
+            self._queue.append((priority, agent))
+            if self.is_paused(agent):
+                continue
+            self.record_metrics(agent)
+            return agent
+
+        raise SchedulingError("PriorityScheduler has no active agents to schedule.")
+
+    def _handle_agent_removal(self, agent: AIAgent) -> None:
+        self._queue = [
+            (priority, queued) for priority, queued in self._queue if queued is not agent
+        ]
+
+
+__all__ = ["PriorityScheduler"]

--- a/neva/schedulers/random.py
+++ b/neva/schedulers/random.py
@@ -1,0 +1,34 @@
+"""Random scheduler implementation."""
+
+from __future__ import annotations
+
+import random
+
+from neva.agents.base import AIAgent
+from neva.schedulers.base import Scheduler
+from neva.utils.exceptions import SchedulingError
+from neva.utils.observer import SimulationObserver
+
+
+class RandomScheduler(Scheduler):
+    """Activate agents in a random order on each scheduling decision."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.simulation_observer = SimulationObserver()
+
+    def add(self, agent: AIAgent, **_: object) -> None:
+        if agent not in self.agents:
+            self.agents.append(agent)
+
+    def get_next_agent(self) -> AIAgent:
+        active_agents = self._active_agents()
+        if not active_agents:
+            raise SchedulingError("RandomScheduler has no active agents to schedule.")
+
+        agent = random.choice(active_agents)
+        self.record_metrics(agent)
+        return agent
+
+
+__all__ = ["RandomScheduler"]

--- a/neva/schedulers/weighted_random.py
+++ b/neva/schedulers/weighted_random.py
@@ -1,0 +1,58 @@
+"""Weighted random scheduler implementation."""
+
+from __future__ import annotations
+
+import random
+from typing import List, Tuple
+
+from neva.agents.base import AIAgent
+from neva.schedulers.base import Scheduler
+from neva.utils.exceptions import SchedulingError
+from neva.utils.observer import SimulationObserver
+
+
+class WeightedRandomScheduler(Scheduler):
+    """Activate agents randomly while respecting configured weights."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.simulation_observer = SimulationObserver()
+        self._entries: List[Tuple[float, AIAgent]] = []
+
+    def add(self, agent: AIAgent, **kwargs: object) -> None:
+        weight = float(kwargs.get("weight", 1.0))
+        self._entries.append((weight, agent))
+        if agent not in self.agents:
+            self.agents.append(agent)
+
+    def get_next_agent(self) -> AIAgent:
+        if not self._entries:
+            raise SchedulingError("WeightedRandomScheduler has no agents to schedule.")
+
+        active_entries = [
+            (weight, agent) for weight, agent in self._entries if not self.is_paused(agent)
+        ]
+        if not active_entries:
+            raise SchedulingError(
+                "WeightedRandomScheduler has no active agents to schedule."
+            )
+
+        total_weight = sum(weight for weight, _ in active_entries)
+        random_weight = random.uniform(0, total_weight)
+        for weight, agent in active_entries:
+            if random_weight <= weight:
+                self.record_metrics(agent)
+                return agent
+            random_weight -= weight
+
+        agent = active_entries[-1][1]
+        self.record_metrics(agent)
+        return agent
+
+    def _handle_agent_removal(self, agent: AIAgent) -> None:
+        self._entries = [
+            (weight, queued) for weight, queued in self._entries if queued is not agent
+        ]
+
+
+__all__ = ["WeightedRandomScheduler"]


### PR DESCRIPTION
## Summary
- move each scheduler implementation into its own module and introduce a pluggable registry API
- add event-driven and conditional schedulers alongside the existing random, priority, LRU, and weighted strategies
- document available schedulers and expand scheduler unit tests to cover the new behaviours and registry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68edc10986108323b9413639f70bdfc8