### PR TITLE
Run isort to normalize import order

### DIFF
--- a/examples/customer_support_demo.py
+++ b/examples/customer_support_demo.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Callable, List, Optional
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 from neva.agents import AgentManager
 from neva.schedulers import RoundRobinScheduler
-
-from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 
 
 class SupportDeskEnvironment(TranscriptEnvironment):

--- a/examples/debate_demo.py
+++ b/examples/debate_demo.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Callable, Dict, List
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 from neva.agents import AgentManager
 from neva.schedulers import RoundRobinScheduler
-
-from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 
 
 class DebateEnvironment(TranscriptEnvironment):

--- a/examples/hierarchical_mission_demo.py
+++ b/examples/hierarchical_mission_demo.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Callable, Dict, Iterable, Iterator
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 from neva.agents import AgentManager
 from neva.schedulers import RoundRobinScheduler
-
-from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 
 
 class MissionControlEnvironment(TranscriptEnvironment):

--- a/examples/productivity_swarm_demo.py
+++ b/examples/productivity_swarm_demo.py
@@ -2,20 +2,19 @@
 
 from __future__ import annotations
 
+import sys
 from collections import deque
 from pathlib import Path
-import sys
 from typing import Callable, Deque, Dict, Iterable, List, Optional
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 from neva.agents import AgentManager
 from neva.schedulers import RoundRobinScheduler
 from neva.tools import MathTool
-
-from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 
 
 class ProductivityEnvironment(TranscriptEnvironment):

--- a/examples/quest_party_demo.py
+++ b/examples/quest_party_demo.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 from neva.agents import AgentManager
 from neva.schedulers import RoundRobinScheduler
-
-from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 
 
 class QuestEncounterEnvironment(TranscriptEnvironment):

--- a/examples/quickstart_conversation.py
+++ b/examples/quickstart_conversation.py
@@ -14,9 +14,8 @@ focus of the project.
 
 from __future__ import annotations
 
-from typing import List
-
 from pathlib import Path
+from typing import List
 
 from neva.agents import AgentManager
 from neva.environments import BasicEnvironment

--- a/examples/run_showcase.py
+++ b/examples/run_showcase.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:

--- a/examples/showcase_common.py
+++ b/examples/showcase_common.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import sys
 from importlib import import_module
 from pathlib import Path
-import sys
 from typing import Callable, List, Optional
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]

--- a/examples/social_scenario_demo.py
+++ b/examples/social_scenario_demo.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Callable, Dict, List
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 from neva.agents import AgentManager
 from neva.schedulers import RoundRobinScheduler
-
-from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 
 
 class CommunityScenarioEnvironment(TranscriptEnvironment):

--- a/examples/tavern_npc_demo.py
+++ b/examples/tavern_npc_demo.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Callable, Iterable, List, Optional
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 from neva.agents import AgentManager
 from neva.schedulers import RoundRobinScheduler
-
-from examples.showcase_common import TranscriptEnvironment, make_persona_backend, run_simulation
 
 
 class TavernEnvironment(TranscriptEnvironment):

--- a/examples/tool_research_demo.py
+++ b/examples/tool_research_demo.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Callable
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
-
-from neva.agents import AgentManager
-from neva.schedulers import RoundRobinScheduler
-from neva.tools import WikipediaTool
 
 from examples.showcase_common import (
     TranscriptEnvironment,
@@ -20,6 +16,9 @@ from examples.showcase_common import (
     make_persona_backend,
     run_simulation,
 )
+from neva.agents import AgentManager
+from neva.schedulers import RoundRobinScheduler
+from neva.tools import WikipediaTool
 
 
 class ResearchLabEnvironment(TranscriptEnvironment):

--- a/neva/agents/__init__.py
+++ b/neva/agents/__init__.py
@@ -1,9 +1,9 @@
 """Agent implementations and supporting abstractions."""
 
 from .base import (
-    AIAgent,
     AgentFactory,
     AgentManager,
+    AIAgent,
     InteractionHistory,
     LLMBackend,
     ParallelExecutionConfig,

--- a/neva/agents/base.py
+++ b/neva/agents/base.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
 from abc import ABC, abstractmethod
 from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime
-import json
-import logging
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/neva/environments/base.py
+++ b/neva/environments/base.py
@@ -11,7 +11,6 @@ from neva.schedulers.base import Scheduler
 from neva.utils.state_management import ConversationState, SimulationSnapshot, create_snapshot
 from neva.utils.telemetry import get_telemetry
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/neva/schedulers/base.py
+++ b/neva/schedulers/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Callable, List, Optional, Set, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, List, Optional, Set
 
 from neva.agents.base import AIAgent
 

--- a/neva/schedulers/conditional.py
+++ b/neva/schedulers/conditional.py
@@ -9,7 +9,6 @@ from neva.schedulers.base import Scheduler
 from neva.utils.exceptions import ConfigurationError, SchedulingError
 from neva.utils.observer import SimulationObserver
 
-
 Condition = Callable[[AIAgent], bool]
 
 

--- a/neva/tools/math.py
+++ b/neva/tools/math.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import ast
-import operator
 import logging
+import operator
 from typing import Callable, Dict
 
 from neva.agents.base import Tool
 from neva.utils.exceptions import ToolExecutionError
-
 
 logger = logging.getLogger(__name__)
 

--- a/neva/tools/summarizer.py
+++ b/neva/tools/summarizer.py
@@ -10,7 +10,6 @@ from neva.utils.exceptions import MissingDependencyError, ToolExecutionError
 
 from .utils import missing_dependency_message
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/neva/tools/translator.py
+++ b/neva/tools/translator.py
@@ -10,7 +10,6 @@ from neva.utils.exceptions import MissingDependencyError, ToolExecutionError
 
 from .utils import missing_dependency_message
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/neva/utils/safety.py
+++ b/neva/utils/safety.py
@@ -6,7 +6,7 @@ import re
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Iterable, List
+from typing import Iterable
 
 from neva.utils.exceptions import (
     PromptValidationError,
@@ -32,7 +32,7 @@ class PromptValidator:
     )
 
     def __post_init__(self) -> None:
-        self._compiled_patterns: List[re.Pattern[str]] = [
+        self._compiled_patterns: list[re.Pattern[str]] = [
             re.compile(pattern, flags=re.IGNORECASE) for pattern in self.forbidden_patterns
         ]
 

--- a/neva/utils/safety.py
+++ b/neva/utils/safety.py
@@ -13,7 +13,6 @@ from neva.utils.exceptions import (
     RateLimiterConfigurationError,
 )
 
-
 CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 
 

--- a/neva/utils/safety.py
+++ b/neva/utils/safety.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import re
 import threading
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Iterable
 
 from neva.utils.exceptions import (
     PromptValidationError,

--- a/neva/utils/state_management.py
+++ b/neva/utils/state_management.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional

--- a/neva/utils/telemetry.py
+++ b/neva/utils/telemetry.py
@@ -29,17 +29,14 @@ def _require_opentelemetry() -> "_OpenTelemetryModules":
     """Import OpenTelemetry modules lazily to keep the dependency optional."""
 
     try:
-        from opentelemetry import logs as otel_logs
-        from opentelemetry import metrics as otel_metrics
-        from opentelemetry import trace as otel_trace
+        from opentelemetry import logs as otel_logs, metrics as otel_metrics, trace as otel_trace
         from opentelemetry.context import Context, set_span_in_context
         from opentelemetry.sdk._logs import LoggerProvider
         from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, LogExporter
         from opentelemetry.sdk._logs.logging import LoggingHandler
         from opentelemetry.sdk.metrics import MeterProvider
         from opentelemetry.sdk.metrics.export import MetricReader
-        from opentelemetry.sdk.resources import Resource
-        from opentelemetry.sdk.resources import SERVICE_NAME as OTEL_SERVICE_NAME
+        from opentelemetry.sdk.resources import SERVICE_NAME as OTEL_SERVICE_NAME, Resource
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
         from opentelemetry.trace import SpanKind

--- a/tests/unit/test_agent_manager.py
+++ b/tests/unit/test_agent_manager.py
@@ -28,7 +28,7 @@ transformers_stub.AutoModelForSeq2SeqLM = DummyAutoModel
 transformers_stub.AutoTokenizer = DummyAutoTokenizer
 sys.modules["transformers"] = transformers_stub
 
-from neva.agents import AgentManager, ParallelExecutionConfig, TransformerAgent, GPTAgent
+from neva.agents import AgentManager, GPTAgent, ParallelExecutionConfig, TransformerAgent
 from neva.utils.exceptions import AgentCreationError
 
 

--- a/tests/unit/test_safety.py
+++ b/tests/unit/test_safety.py
@@ -1,7 +1,5 @@
 import pytest
 
-import pytest
-
 from neva.utils import safety
 from neva.utils.exceptions import PromptValidationError
 


### PR DESCRIPTION
## Summary
- reorder imports in example scripts to align with the configured isort style
- normalize import ordering across core utilities, agents, and schedulers modules
- tidy unit test imports for consistency with the rest of the project

## Testing
- isort --check-only .

------
https://chatgpt.com/codex/tasks/task_e_68ee4811e97c83238d0251ec2735d321