### PR TITLE
Configure flake8 and resolve lint warnings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503
+per-file-ignores =
+    examples/*.py: E402
+    tests/**/*.py: E402

--- a/neva/agents/base.py
+++ b/neva/agents/base.py
@@ -20,7 +20,6 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    Set,
     Tuple,
     Union,
 )

--- a/neva/memory/faiss_vector_store.py
+++ b/neva/memory/faiss_vector_store.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Callable, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Tuple
 
 from neva.utils.exceptions import MemoryConfigurationError
 
 from .base import MemoryModule, MemoryRecord
+
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only.
+    import numpy as np
 
 
 class FaissVectorStoreMemory(MemoryModule):

--- a/neva/schedulers/base.py
+++ b/neva/schedulers/base.py
@@ -9,7 +9,6 @@ from neva.agents.base import AIAgent
 
 if TYPE_CHECKING:  # pragma: no cover - import used only for typing.
     from neva.environments.base import Environment
-    from neva.utils.observer import SimulationObserver
 
 
 class Scheduler(ABC):

--- a/neva/schedulers/conditional.py
+++ b/neva/schedulers/conditional.py
@@ -24,7 +24,10 @@ class ConditionalScheduler(Scheduler):
     def add(self, agent: AIAgent, **kwargs: object) -> None:
         condition = kwargs.get("condition") or kwargs.get("predicate")
         if condition is None:
-            condition = lambda _: True
+            def _always_true(_: AIAgent) -> bool:
+                return True
+
+            condition = _always_true
         if not callable(condition):
             raise ConfigurationError("ConditionalScheduler requires a callable condition.")
 

--- a/tests/unit/test_schedulers.py
+++ b/tests/unit/test_schedulers.py
@@ -114,7 +114,8 @@ def test_conditional_scheduler_respects_agent_state():
     ready.ready = True
     waiting.ready = False
 
-    predicate = lambda agent: getattr(agent, "ready", False)
+    def predicate(agent: StubAgent) -> bool:
+        return getattr(agent, "ready", False)
     scheduler.add(ready, condition=predicate)
     scheduler.add(waiting, condition=predicate)
 


### PR DESCRIPTION
## Summary
- add a repository-level flake8 configuration to align linting with project conventions and ignore script-style imports in examples and tests
- clean up unused or typing-only imports to satisfy flake8 checks
- replace lambda predicates with named helper functions to comply with flake8 E731

## Testing
- python -m flake8

------
https://chatgpt.com/codex/tasks/task_e_68ee64aaea088323be23be2a7499f606