### PR TITLE
Fix mypy violations across utilities and schedulers

### DIFF
--- a/neva/agents/gpt.py
+++ b/neva/agents/gpt.py
@@ -8,7 +8,7 @@ from time import perf_counter, sleep
 from typing import Dict, Optional
 
 import openai
-import requests
+import requests  # type: ignore[import-untyped]
 
 from neva.agents.base import AIAgent, LLMBackend
 from neva.memory import MemoryModule

--- a/neva/agents/transformer.py
+++ b/neva/agents/transformer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from neva.agents.base import AIAgent, LLMBackend
 from neva.memory import MemoryModule
@@ -40,10 +40,10 @@ class TransformerAgent(AIAgent):
             prompt_validator=prompt_validator,
         )
         self.model_name = model_name
-        self._model_loader = model_loader
-        self._tokenizer_loader = tokenizer_loader
-        self._model = None
-        self._tokenizer = None
+        self._model_loader: Optional[Callable[[str], Any]] = model_loader
+        self._tokenizer_loader: Optional[Callable[[str], Any]] = tokenizer_loader
+        self._model: Optional[Any] = None
+        self._tokenizer: Optional[Any] = None
 
     def _load_transformer(self) -> None:
         if self.llm_backend is not None:
@@ -63,6 +63,9 @@ class TransformerAgent(AIAgent):
 
             loader = AutoModelForSeq2SeqLM.from_pretrained
             tokenizer_loader = AutoTokenizer.from_pretrained
+
+        if loader is None or tokenizer_loader is None:
+            raise BackendUnavailableError("Model and tokenizer loaders must be provided")
 
         self._model = loader(self.model_name)
         self._tokenizer = tokenizer_loader(self.model_name)

--- a/neva/memory/faiss_vector_store.py
+++ b/neva/memory/faiss_vector_store.py
@@ -1,4 +1,5 @@
 """FAISS-backed vector memory implementation."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Tuple

--- a/neva/schedulers/__init__.py
+++ b/neva/schedulers/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, List, Optional, Type, TypeVar
+from typing import Dict, Iterable, List, Optional, Type, TypeVar, cast
 
 from neva.utils.exceptions import ConfigurationError
 
@@ -88,13 +88,13 @@ def get_scheduler_class(name: str) -> Type[SchedulerType]:
     """Return the registered scheduler class for ``name``."""
 
     canonical = _resolve_to_canonical(name)
-    return _REGISTRY[canonical]
+    return cast(Type[SchedulerType], _REGISTRY[canonical])
 
 
 def create_scheduler(name: str, **kwargs: object) -> Scheduler:
     """Instantiate the scheduler associated with ``name``."""
 
-    scheduler_cls = get_scheduler_class(name)
+    scheduler_cls: Type[Scheduler] = get_scheduler_class(name)
     return scheduler_cls(**kwargs)
 
 

--- a/neva/schedulers/composite.py
+++ b/neva/schedulers/composite.py
@@ -39,9 +39,7 @@ class CompositeScheduler(Scheduler):
             raise ConfigurationError("group must be provided as a string")
         group = raw_group
         scheduler_override_obj = kwargs.pop("scheduler", None)
-        if scheduler_override_obj is not None and not isinstance(
-            scheduler_override_obj, Scheduler
-        ):
+        if scheduler_override_obj is not None and not isinstance(scheduler_override_obj, Scheduler):
             raise ConfigurationError("scheduler override must inherit from Scheduler")
         scheduler_override = cast(Optional[Scheduler], scheduler_override_obj)
 

--- a/neva/schedulers/priority.py
+++ b/neva/schedulers/priority.py
@@ -19,7 +19,13 @@ class PriorityScheduler(Scheduler):
         self._queue: List[Tuple[int, AIAgent]] = []
 
     def add(self, agent: AIAgent, **kwargs: object) -> None:
-        priority = int(kwargs.get("priority", 1))
+        raw_priority = kwargs.get("priority", 1)
+        if not isinstance(raw_priority, (int, float, str)):
+            raise SchedulingError("priority must be an integer value")
+        try:
+            priority = int(raw_priority)
+        except ValueError:
+            raise SchedulingError("priority must be an integer value") from None
         self._queue.append((priority, agent))
         if agent not in self.agents:
             self.agents.append(agent)

--- a/neva/schedulers/weighted_random.py
+++ b/neva/schedulers/weighted_random.py
@@ -20,7 +20,13 @@ class WeightedRandomScheduler(Scheduler):
         self._entries: List[Tuple[float, AIAgent]] = []
 
     def add(self, agent: AIAgent, **kwargs: object) -> None:
-        weight = float(kwargs.get("weight", 1.0))
+        raw_weight = kwargs.get("weight", 1.0)
+        if not isinstance(raw_weight, (int, float, str)):
+            raise SchedulingError("weight must be convertible to float")
+        try:
+            weight = float(raw_weight)
+        except ValueError:
+            raise SchedulingError("weight must be convertible to float") from None
         self._entries.append((weight, agent))
         if agent not in self.agents:
             self.agents.append(agent)

--- a/neva/tools/math.py
+++ b/neva/tools/math.py
@@ -35,7 +35,10 @@ class MathTool(Tool):
 
     def _eval_node(self, node: ast.AST) -> float:
         if isinstance(node, ast.Num):  # pragma: no cover - python<3.8 fallback
-            return float(node.n)  # type: ignore[attr-defined]
+            value = node.n  # type: ignore[attr-defined]
+            if isinstance(value, (int, float)):
+                return float(value)
+            raise ToolExecutionError("Unsupported numeric literal type")
         if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
             return float(node.value)
         if isinstance(node, ast.BinOp):

--- a/neva/utils/caching.py
+++ b/neva/utils/caching.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from threading import RLock
-from typing import MutableMapping, Optional
+from typing import Optional
 
 from neva.utils.exceptions import CacheConfigurationError
 
@@ -16,7 +16,7 @@ class LLMCache:
         if max_size <= 0:
             raise CacheConfigurationError("max_size must be a positive integer")
         self._max_size = max_size
-        self._store: MutableMapping[str, str] = OrderedDict()
+        self._store: OrderedDict[str, str] = OrderedDict()
         self._lock = RLock()
 
     def get(self, prompt: str) -> Optional[str]:

--- a/neva/utils/observer.py
+++ b/neva/utils/observer.py
@@ -30,8 +30,7 @@ from neva.utils.telemetry import get_telemetry
 class ToolLike(Protocol):
     """Protocol describing the ``use`` method exposed by tools."""
 
-    def use(self, *args: Any, **kwargs: Any) -> Any:
-        ...
+    def use(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
 ContextDict = Dict[str, Any]

--- a/neva/utils/safety.py
+++ b/neva/utils/safety.py
@@ -1,4 +1,5 @@
 """Safety and validation helpers for user provided prompts."""
+
 from __future__ import annotations
 
 import re


### PR DESCRIPTION
## Summary
- tighten typing in telemetry utilities by loading OpenTelemetry modules via importlib, tracking fallback state explicitly, and normalising span metadata
- harden state persistence, tool handling, and scheduler configuration against invalid inputs to satisfy static analysis
- align helper utilities (math tool, caching, transformer agent) with mypy expectations and add missing stub suppressions

## Testing
- `mypy neva`


------
https://chatgpt.com/codex/tasks/task_e_68ef0fb2e9b88323b9df6c6c013e976c