### PR TITLE
Fix mypy type issues across agents, schedulers, and utils

### DIFF
--- a/neva/agents/gpt.py
+++ b/neva/agents/gpt.py
@@ -8,7 +8,7 @@ from time import perf_counter, sleep
 from typing import Dict, Optional
 
 import openai
-import requests
+import requests  # type: ignore[import-untyped]
 
 from neva.agents.base import AIAgent, LLMBackend
 from neva.memory import MemoryModule

--- a/neva/agents/transformer.py
+++ b/neva/agents/transformer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from neva.agents.base import AIAgent, LLMBackend
 from neva.memory import MemoryModule
@@ -42,8 +42,8 @@ class TransformerAgent(AIAgent):
         self.model_name = model_name
         self._model_loader = model_loader
         self._tokenizer_loader = tokenizer_loader
-        self._model = None
-        self._tokenizer = None
+        self._model: Any = None
+        self._tokenizer: Any = None
 
     def _load_transformer(self) -> None:
         if self.llm_backend is not None:
@@ -64,6 +64,8 @@ class TransformerAgent(AIAgent):
             loader = AutoModelForSeq2SeqLM.from_pretrained
             tokenizer_loader = AutoTokenizer.from_pretrained
 
+        assert loader is not None
+        assert tokenizer_loader is not None
         self._model = loader(self.model_name)
         self._tokenizer = tokenizer_loader(self.model_name)
 

--- a/neva/schedulers/__init__.py
+++ b/neva/schedulers/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, List, Optional, Type, TypeVar
+from typing import Dict, Iterable, List, Optional, Type
 
 from neva.utils.exceptions import ConfigurationError
 
@@ -15,8 +15,6 @@ from .priority import PriorityScheduler
 from .random import RandomScheduler
 from .round_robin import RoundRobinScheduler
 from .weighted_random import WeightedRandomScheduler
-
-SchedulerType = TypeVar("SchedulerType", bound=Scheduler)
 
 _REGISTRY: Dict[str, Type[Scheduler]] = {}
 _ALIASES: Dict[str, str] = {}
@@ -47,7 +45,7 @@ def _resolve_to_canonical(name: str) -> str:
 
 def register_scheduler(
     name: str,
-    scheduler_cls: Type[SchedulerType],
+    scheduler_cls: Type[Scheduler],
     *,
     overwrite: bool = False,
     aliases: Optional[Iterable[str]] = None,
@@ -84,7 +82,7 @@ def unregister_scheduler(name: str) -> None:
             _ALIASES.pop(alias)
 
 
-def get_scheduler_class(name: str) -> Type[SchedulerType]:
+def get_scheduler_class(name: str) -> Type[Scheduler]:
     """Return the registered scheduler class for ``name``."""
 
     canonical = _resolve_to_canonical(name)

--- a/neva/schedulers/composite.py
+++ b/neva/schedulers/composite.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, cast
 
 from neva.agents.base import AIAgent
 from neva.schedulers.base import Scheduler
@@ -34,8 +34,14 @@ class CompositeScheduler(Scheduler):
             scheduler.set_environment(environment)
 
     def add(self, agent: AIAgent, **kwargs: object) -> None:
-        group = kwargs.pop("group", "default")
-        scheduler_override = kwargs.pop("scheduler", None)
+        group_value = kwargs.pop("group", "default")
+        if not isinstance(group_value, str):
+            raise ConfigurationError("group must be provided as a string")
+        group = group_value
+        scheduler_value = kwargs.pop("scheduler", None)
+        if scheduler_value is not None and not isinstance(scheduler_value, Scheduler):
+            raise ConfigurationError("scheduler override must inherit from Scheduler")
+        scheduler_override = cast(Optional[Scheduler], scheduler_value)
 
         existing_group = self._group_membership.get(agent)
         if existing_group is not None and existing_group != group:
@@ -64,6 +70,8 @@ class CompositeScheduler(Scheduler):
             try:
                 agent = scheduler.get_next_agent()
             except SchedulingError:
+                continue
+            if agent is None:
                 continue
             if self.is_paused(agent):
                 scheduler.pause(agent)

--- a/neva/schedulers/priority.py
+++ b/neva/schedulers/priority.py
@@ -19,7 +19,16 @@ class PriorityScheduler(Scheduler):
         self._queue: List[Tuple[int, AIAgent]] = []
 
     def add(self, agent: AIAgent, **kwargs: object) -> None:
-        priority = int(kwargs.get("priority", 1))
+        raw_priority = kwargs.get("priority", 1)
+        if isinstance(raw_priority, (int, float)):
+            priority = int(raw_priority)
+        elif isinstance(raw_priority, str):
+            try:
+                priority = int(raw_priority)
+            except ValueError as exc:
+                raise SchedulingError("priority must be an integer value") from exc
+        else:
+            raise SchedulingError("priority must be an integer value")
         self._queue.append((priority, agent))
         if agent not in self.agents:
             self.agents.append(agent)

--- a/neva/schedulers/weighted_random.py
+++ b/neva/schedulers/weighted_random.py
@@ -20,7 +20,16 @@ class WeightedRandomScheduler(Scheduler):
         self._entries: List[Tuple[float, AIAgent]] = []
 
     def add(self, agent: AIAgent, **kwargs: object) -> None:
-        weight = float(kwargs.get("weight", 1.0))
+        raw_weight = kwargs.get("weight", 1.0)
+        if isinstance(raw_weight, (int, float)):
+            weight = float(raw_weight)
+        elif isinstance(raw_weight, str):
+            try:
+                weight = float(raw_weight)
+            except ValueError as exc:
+                raise SchedulingError("weight must be a numeric value") from exc
+        else:
+            raise SchedulingError("weight must be a numeric value")
         self._entries.append((weight, agent))
         if agent not in self.agents:
             self.agents.append(agent)

--- a/neva/tools/math.py
+++ b/neva/tools/math.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ast
 import logging
 import operator
-from typing import Callable, Dict
+from typing import Callable, Dict, Union, cast
 
 from neva.agents.base import Tool
 from neva.utils.exceptions import ToolExecutionError
@@ -35,9 +35,11 @@ class MathTool(Tool):
 
     def _eval_node(self, node: ast.AST) -> float:
         if isinstance(node, ast.Num):  # pragma: no cover - python<3.8 fallback
-            return float(node.n)  # type: ignore[attr-defined]
+            numeric_value = cast(Union[int, float], getattr(node, "n"))
+            return float(numeric_value)
         if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
-            return float(node.value)
+            value: Union[int, float] = cast(Union[int, float], node.value)
+            return float(value)
         if isinstance(node, ast.BinOp):
             op_type = type(node.op)
             if op_type not in _ALLOWED_OPERATORS:

--- a/neva/utils/caching.py
+++ b/neva/utils/caching.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from threading import RLock
-from typing import MutableMapping, Optional
+from typing import Optional
 
 from neva.utils.exceptions import CacheConfigurationError
 
@@ -16,7 +16,7 @@ class LLMCache:
         if max_size <= 0:
             raise CacheConfigurationError("max_size must be a positive integer")
         self._max_size = max_size
-        self._store: MutableMapping[str, str] = OrderedDict()
+        self._store: OrderedDict[str, str] = OrderedDict()
         self._lock = RLock()
 
     def get(self, prompt: str) -> Optional[str]:

--- a/neva/utils/state_management.py
+++ b/neva/utils/state_management.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, is_dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
@@ -47,9 +47,11 @@ class ConversationState:
     @classmethod
     def from_dict(cls, payload: Dict[str, object]) -> "ConversationState":
         state = cls(agent_name=str(payload["agent_name"]))
-        turns = payload.get("turns", [])
-        for turn_payload in turns:  # type: ignore[assignment]
-            state.turns.append(ConversationTurn.from_dict(turn_payload))
+        raw_turns = payload.get("turns", [])
+        if isinstance(raw_turns, list):
+            for turn_payload in raw_turns:
+                if isinstance(turn_payload, dict):
+                    state.turns.append(ConversationTurn.from_dict(turn_payload))
         return state
 
 
@@ -86,8 +88,13 @@ def create_snapshot(
     agent_states: Optional[Iterable[ConversationState]] = None,
 ) -> SimulationSnapshot:
     environment_state = environment_state or {}
+    if agent_states is None:
+        agent_state_iter: Iterable[ConversationState] = ()
+    else:
+        agent_state_iter = agent_states
+
     agent_snapshot: Dict[str, Dict[str, object]] = {}
-    for state in agent_states or []:
+    for state in agent_state_iter:
         agent_snapshot[state.agent_name] = state.to_dict()
     return SimulationSnapshot(
         created_at=datetime.utcnow(),
@@ -109,6 +116,6 @@ def _json_default(value: object) -> Any:
         return value.isoformat()
     if hasattr(value, "to_dict"):
         return value.to_dict()
-    if hasattr(value, "__dataclass_fields__"):
+    if is_dataclass(value) and not isinstance(value, type):
         return asdict(value)
     raise TypeError(f"Object of type {type(value).__name__} is not JSON serialisable")


### PR DESCRIPTION
## Summary
- tighten optional dependency loading and telemetry bookkeeping to satisfy mypy while preserving graceful fallbacks
- adjust state persistence, caching, math tooling, and scheduler helpers to accept only well-typed inputs
- clean up agent utilities to normalise tool arguments and properly annotate transformer loader hooks

## Testing
- `mypy neva`


------
https://chatgpt.com/codex/tasks/task_e_68ef6b3880a48323ab1d1554ad1ae192