### PR TITLE
Fix mypy errors across utilities and schedulers

### DIFF
--- a/neva/schedulers/__init__.py
+++ b/neva/schedulers/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, List, Optional, Type, TypeVar
+from typing import Dict, Iterable, List, Optional, Type, TypeVar, cast
 
 from neva.utils.exceptions import ConfigurationError
 
@@ -88,14 +88,15 @@ def get_scheduler_class(name: str) -> Type[SchedulerType]:
     """Return the registered scheduler class for ``name``."""
 
     canonical = _resolve_to_canonical(name)
-    return _REGISTRY[canonical]
+    return cast(Type[SchedulerType], _REGISTRY[canonical])
 
 
 def create_scheduler(name: str, **kwargs: object) -> Scheduler:
     """Instantiate the scheduler associated with ``name``."""
 
-    scheduler_cls = get_scheduler_class(name)
-    return scheduler_cls(**kwargs)
+    scheduler_cls = cast(Type[Scheduler], get_scheduler_class(name))
+    scheduler = scheduler_cls(**kwargs)
+    return cast(Scheduler, scheduler)
 
 
 def available_schedulers() -> List[str]:

--- a/neva/schedulers/priority.py
+++ b/neva/schedulers/priority.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import Any, List, Tuple, cast
 
 from neva.agents.base import AIAgent
 from neva.schedulers.base import Scheduler
@@ -19,7 +19,11 @@ class PriorityScheduler(Scheduler):
         self._queue: List[Tuple[int, AIAgent]] = []
 
     def add(self, agent: AIAgent, **kwargs: object) -> None:
-        priority = int(kwargs.get("priority", 1))
+        raw_priority = kwargs.get("priority", 1)
+        try:
+            priority = int(cast(Any, raw_priority))
+        except (TypeError, ValueError):
+            raise SchedulingError("priority must be an integer value") from None
         self._queue.append((priority, agent))
         if agent not in self.agents:
             self.agents.append(agent)

--- a/neva/schedulers/weighted_random.py
+++ b/neva/schedulers/weighted_random.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import random
-from typing import List, Tuple
+from typing import Any, List, Tuple, cast
 
 from neva.agents.base import AIAgent
 from neva.schedulers.base import Scheduler
@@ -20,7 +20,11 @@ class WeightedRandomScheduler(Scheduler):
         self._entries: List[Tuple[float, AIAgent]] = []
 
     def add(self, agent: AIAgent, **kwargs: object) -> None:
-        weight = float(kwargs.get("weight", 1.0))
+        raw_weight = kwargs.get("weight", 1.0)
+        try:
+            weight = float(cast(Any, raw_weight))
+        except (TypeError, ValueError):
+            raise SchedulingError("weight must be a numeric value") from None
         self._entries.append((weight, agent))
         if agent not in self.agents:
             self.agents.append(agent)

--- a/neva/tools/math.py
+++ b/neva/tools/math.py
@@ -35,7 +35,10 @@ class MathTool(Tool):
 
     def _eval_node(self, node: ast.AST) -> float:
         if isinstance(node, ast.Num):  # pragma: no cover - python<3.8 fallback
-            return float(node.n)  # type: ignore[attr-defined]
+            value = node.n  # type: ignore[attr-defined]
+            if isinstance(value, (int, float)):
+                return float(value)
+            raise ToolExecutionError("Unsupported number type")
         if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
             return float(node.value)
         if isinstance(node, ast.BinOp):

--- a/neva/utils/caching.py
+++ b/neva/utils/caching.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from threading import RLock
-from typing import MutableMapping, Optional
+from typing import Optional
 
 from neva.utils.exceptions import CacheConfigurationError
 
@@ -16,7 +16,7 @@ class LLMCache:
         if max_size <= 0:
             raise CacheConfigurationError("max_size must be a positive integer")
         self._max_size = max_size
-        self._store: MutableMapping[str, str] = OrderedDict()
+        self._store: OrderedDict[str, str] = OrderedDict()
         self._lock = RLock()
 
     def get(self, prompt: str) -> Optional[str]:


### PR DESCRIPTION
## Summary
- tighten JSON snapshot handling and cache typing so persistence helpers remain mypy-safe
- refine telemetry manager imports, fallbacks, and logging payloads to satisfy type checking without losing functionality
- normalize agent tooling and scheduler inputs, including transformer loaders and math tool evaluation, to align with strict typing

## Testing
- isort .
- black .
- flake8
- mypy neva

------
https://chatgpt.com/codex/tasks/task_e_68efe895afa88323ac477bf2dae82442