### PR TITLE
Ensure scheduler random modules expose patchable random objects

### DIFF
--- a/neva/schedulers/random.py
+++ b/neva/schedulers/random.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from random import SystemRandom
+import random
+import sys
 
 from neva.agents.base import AIAgent
 from neva.schedulers.base import Scheduler
@@ -16,7 +17,7 @@ class RandomScheduler(Scheduler):
     def __init__(self) -> None:
         super().__init__()
         self.simulation_observer = SimulationObserver()
-        self._rng = SystemRandom()
+        self._rng = random
 
     def add(self, agent: AIAgent, **_: object) -> None:
         if agent not in self.agents:
@@ -33,3 +34,8 @@ class RandomScheduler(Scheduler):
 
 
 __all__ = ["RandomScheduler"]
+
+# Allow ``monkeypatch.setattr("neva.schedulers.random.random.choice", ...)``
+# by registering the standard library ``random`` module as a submodule of this
+# scheduler module.
+sys.modules.setdefault(__name__ + ".random", random)

--- a/neva/schedulers/weighted_random.py
+++ b/neva/schedulers/weighted_random.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from random import SystemRandom
+import random
+import sys
 from typing import Any, List, Tuple, cast
 
 from neva.agents.base import AIAgent
@@ -18,7 +19,7 @@ class WeightedRandomScheduler(Scheduler):
         super().__init__()
         self.simulation_observer = SimulationObserver()
         self._entries: List[Tuple[float, AIAgent]] = []
-        self._rng = SystemRandom()
+        self._rng = random
 
     def add(self, agent: AIAgent, **kwargs: object) -> None:
         raw_weight = kwargs.get("weight", 1.0)
@@ -59,3 +60,7 @@ class WeightedRandomScheduler(Scheduler):
 
 
 __all__ = ["WeightedRandomScheduler"]
+
+# Register ``random`` as a submodule so tests can monkeypatch
+# ``neva.schedulers.weighted_random.random`` directly.
+sys.modules.setdefault(__name__ + ".random", random)


### PR DESCRIPTION
## Summary
- update the random and weighted random schedulers to use the stdlib random module
- register the stdlib random module as a submodule so monkeypatching works as expected

## Testing
- pytest --override-ini addopts='' tests/unit/test_schedulers.py

------
https://chatgpt.com/codex/tasks/task_e_68eff79748b88323a7e834e192fd673b