### PR TITLE
Improve transformer optional dependency typing

### DIFF
--- a/neva/agents/transformer.py
+++ b/neva/agents/transformer.py
@@ -10,6 +10,7 @@ from neva.utils.caching import LLMCache
 from neva.utils.exceptions import BackendUnavailableError
 from neva.utils.safety import PromptValidator
 
+
 class _TransformerModel(Protocol):
     """Protocol for transformer models used by :class:`TransformerAgent`."""
 

--- a/neva/agents/transformer.py
+++ b/neva/agents/transformer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Optional, cast
+from typing import Any, Callable, Mapping, Optional, Protocol, Sequence, cast
 
 from neva.agents.base import AIAgent, LLMBackend
 from neva.memory import MemoryModule
@@ -10,11 +10,36 @@ from neva.utils.caching import LLMCache
 from neva.utils.exceptions import BackendUnavailableError
 from neva.utils.safety import PromptValidator
 
+class _TransformerModel(Protocol):
+    """Protocol for transformer models used by :class:`TransformerAgent`."""
+
+    def generate(self, **kwargs: Any) -> Sequence[Any]:
+        """Generate tokens from the provided model inputs."""
+
+
+class _TransformerTokenizer(Protocol):
+    """Protocol describing the tokenizer surface used by the agent."""
+
+    def __call__(self, text: str, **kwargs: Any) -> Mapping[str, Any]:
+        """Tokenize ``text`` and return the model inputs."""
+
+    def decode(self, token_ids: Any, *, skip_special_tokens: bool = ...) -> str:
+        """Convert ``token_ids`` back into natural language text."""
+
+
+ModelLoader = Callable[[str], _TransformerModel]
+TokenizerLoader = Callable[[str], _TransformerTokenizer]
+
+
 try:  # pragma: no cover - optional dependency
-    from transformers import AutoModelForSeq2SeqLM, AutoTokenizer  # type: ignore
+    from transformers import AutoModelForSeq2SeqLM as _AutoModelForSeq2SeqLM
+    from transformers import AutoTokenizer as _AutoTokenizer
 except Exception:  # pragma: no cover - handled at runtime
-    AutoModelForSeq2SeqLM = cast(Any, None)
-    AutoTokenizer = cast(Any, None)
+    _DEFAULT_MODEL_LOADER: Optional[ModelLoader] = None
+    _DEFAULT_TOKENIZER_LOADER: Optional[TokenizerLoader] = None
+else:  # pragma: no cover - exercised when transformers is installed
+    _DEFAULT_MODEL_LOADER = cast(ModelLoader, _AutoModelForSeq2SeqLM.from_pretrained)
+    _DEFAULT_TOKENIZER_LOADER = cast(TokenizerLoader, _AutoTokenizer.from_pretrained)
 
 
 class TransformerAgent(AIAgent):
@@ -28,8 +53,8 @@ class TransformerAgent(AIAgent):
         llm_backend: Optional[LLMBackend] = None,
         memory: Optional[MemoryModule] = None,
         cache: Optional[LLMCache] = None,
-        model_loader: Optional[Callable[[str], object]] = None,
-        tokenizer_loader: Optional[Callable[[str], object]] = None,
+        model_loader: Optional[ModelLoader] = None,
+        tokenizer_loader: Optional[TokenizerLoader] = None,
         prompt_validator: Optional[PromptValidator] = None,
     ) -> None:
         super().__init__(
@@ -40,10 +65,10 @@ class TransformerAgent(AIAgent):
             prompt_validator=prompt_validator,
         )
         self.model_name = model_name
-        self._model_loader = model_loader
-        self._tokenizer_loader = tokenizer_loader
-        self._model: Optional[Any] = None
-        self._tokenizer: Optional[Any] = None
+        self._model_loader: Optional[ModelLoader] = model_loader
+        self._tokenizer_loader: Optional[TokenizerLoader] = tokenizer_loader
+        self._model: Optional[_TransformerModel] = None
+        self._tokenizer: Optional[_TransformerTokenizer] = None
 
     def _load_transformer(self) -> None:
         if self.llm_backend is not None:
@@ -51,24 +76,26 @@ class TransformerAgent(AIAgent):
         if self._model is not None and self._tokenizer is not None:
             return
 
-        loader = self._model_loader
+        model_loader = self._model_loader
         tokenizer_loader = self._tokenizer_loader
 
-        if loader is None or tokenizer_loader is None:
-            if AutoModelForSeq2SeqLM is None or AutoTokenizer is None:
+        if model_loader is None or tokenizer_loader is None:
+            if _DEFAULT_MODEL_LOADER is None or _DEFAULT_TOKENIZER_LOADER is None:
                 raise BackendUnavailableError(
                     "Transformers library is not available. Provide an ``llm_backend`` "
                     "or install `transformers` to use TransformerAgent."
                 )
 
-            loader = cast(Callable[[str], Any], AutoModelForSeq2SeqLM.from_pretrained)
-            tokenizer_loader = cast(Callable[[str], Any], AutoTokenizer.from_pretrained)
+            model_loader = _DEFAULT_MODEL_LOADER
+            tokenizer_loader = _DEFAULT_TOKENIZER_LOADER
 
-        actual_loader = cast(Callable[[str], Any], loader)
-        actual_tokenizer_loader = cast(Callable[[str], Any], tokenizer_loader)
+        if model_loader is None or tokenizer_loader is None:
+            raise BackendUnavailableError(
+                "Transformer loader functions are unavailable despite transformers being installed."
+            )
 
-        self._model = actual_loader(self.model_name)
-        self._tokenizer = actual_tokenizer_loader(self.model_name)
+        self._model = model_loader(self.model_name)
+        self._tokenizer = tokenizer_loader(self.model_name)
 
     def respond(self, message: str) -> str:
         prompt = self.prepare_prompt(message)

--- a/neva/utils/observer.py
+++ b/neva/utils/observer.py
@@ -30,8 +30,7 @@ from neva.utils.telemetry import get_telemetry
 class ToolLike(Protocol):
     """Protocol describing the ``use`` method exposed by tools."""
 
-    def use(self, *args: Any, **kwargs: Any) -> Any:
-        ...
+    def use(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
 ContextDict = Dict[str, Any]

--- a/neva/utils/safety.py
+++ b/neva/utils/safety.py
@@ -1,4 +1,5 @@
 """Safety and validation helpers for user provided prompts."""
+
 from __future__ import annotations
 
 import re

--- a/neva/utils/state_management.py
+++ b/neva/utils/state_management.py
@@ -114,8 +114,7 @@ def load_snapshot(path: Path) -> SimulationSnapshot:
 
 @runtime_checkable
 class _SupportsToDict(Protocol):
-    def to_dict(self) -> Dict[str, Any]:
-        ...
+    def to_dict(self) -> Dict[str, Any]: ...
 
 
 def _json_default(value: object) -> Any:


### PR DESCRIPTION
## Summary
- introduce protocols describing the minimal transformer model and tokenizer interfaces
- type default loader callables for optional transformers dependency fallbacks
- update the agent to use the protocol-aware loaders instead of ``Any``

## Testing
- pytest *(fails: missing pytest-cov plugin in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f37b412dfc83239f8abc50e60325e4