### PR TITLE
Finalize packaging and docs for publication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+dist/
+*.egg-info/
+*.egg
+wheels/
+share/python-wheels/
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+.pytest_cache/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+.cache
+nosetests.xml
+.tox/
+.nox/
+
+# Type checking / linting caches
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.ruff_cache/
+
+# Sphinx documentation
+docs/_build/
+docs/reference/generated/
+
+# Environments
+.env
+.venv/
+venv/
+env/
+ENV/
+
+# Editors / IDEs
+.idea/
+.vscode/
+*.swp
+*~
+.DS_Store
+
+# Poetry / packaging lock artifacts that should not be committed by accident
+*.whl
+
+# Project-specific runtime artifacts
+quickstart_metrics.json
+*_metrics.json
+mlruns/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Packaging metadata for distribution: project URLs, keywords, and trove
+  classifiers in `pyproject.toml`.
+- PEP 561 `py.typed` marker so downstream projects consume Neva's type hints.
+- `memory` extra bundling the optional `faiss-cpu` and `numpy` dependencies used
+  by the FAISS vector store.
+- Repository `.gitignore` covering build, coverage, cache, and runtime
+  artifacts.
+
+### Fixed
+- Corrected a malformed `RUN` instruction in the `Dockerfile` that contained a
+  stray line continuation.
+- Updated the README "Last Commit" badge to point at the `main` branch.
+
 ## [0.1.0] - 2024-05-01
 ### Added
-- Initial project restructuring introducing the `neva` package with dedicated modules for agents, environments, schedulers, tools, memory, and utilities.
+- Initial project restructuring introducing the `neva` package with dedicated
+  modules for agents, environments, schedulers, tools, memory, and utilities.
+- Agent abstractions including a stub-friendly `TransformerAgent` and a
+  multi-provider `GPTAgent` (OpenAI, Anthropic, Gemini, Grok).
+- Pluggable scheduler registry with round-robin, random, priority,
+  least-recently-used, weighted-random, event-driven, conditional, and composite
+  strategies.
+- Memory integrations spanning short-term, summary, composite, adaptive, and
+  budget stores plus an optional FAISS-backed vector store.
+- Built-in tools for arithmetic, summarisation, translation, and encyclopedia
+  lookups with graceful fallbacks when optional dependencies are absent.
+- Observability utilities: structured logging, a metrics-collecting
+  `SimulationObserver`, and a vendor-neutral OpenTelemetry instrumentation layer.
+- Safety rails (prompt validation/sanitisation, rate limiting, retries),
+  snapshot/restore state management, examples, Sphinx documentation, and a CI
+  pipeline enforcing formatting, linting, typing, security, and 80% test
+  coverage.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,4 +6,9 @@ We are committed to fostering a welcoming and inclusive community. All participa
 - Provide constructive feedback and accept it graciously.
 - Uphold professional conduct and refrain from harassment or discrimination of any kind.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainers at `maintainers@example.com`.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported privately to the project maintainers. Reach out to the repository owner
+[@davletovb](https://github.com/davletovb), or open a confidential report through
+GitHub's [private reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+feature on the repository. All reports will be reviewed and investigated promptly
+and fairly.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ARG WITH_EXTRAS=""
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1
 
-RUN apt-get update \ \
-    && apt-get install --no-install-recommends -y build-essential curl \ \
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential curl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir "poetry==${POETRY_VERSION}"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Coverage](https://img.shields.io/badge/Coverage-80%25-brightgreen.svg)](#testing--quality-assurance)
 [![Issues](https://img.shields.io/github/issues/davletovb/neva)](https://github.com/davletovb/neva/issues)
-[![Last Commit](https://img.shields.io/github/last-commit/davletovb/neva)](https://github.com/davletovb/neva/commits/master)
+[![Last Commit](https://img.shields.io/github/last-commit/davletovb/neva)](https://github.com/davletovb/neva/commits/main)
 [![Contributors](https://img.shields.io/github/contributors/davletovb/neva)](https://github.com/davletovb/neva/graphs/contributors)
 [![Forks](https://img.shields.io/github/forks/davletovb/neva?style=social)](https://github.com/davletovb/neva/fork)
 [![Stars](https://img.shields.io/github/stars/davletovb/neva?style=social)](https://github.com/davletovb/neva/stargazers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,37 @@ description = "Neva provides agent, environment, and scheduler abstractions for 
 authors = ["Neva Contributors"]
 readme = "README.md"
 license = "MIT"
+homepage = "https://github.com/davletovb/neva"
+repository = "https://github.com/davletovb/neva"
+documentation = "https://github.com/davletovb/neva#readme"
+keywords = [
+    "llm",
+    "agents",
+    "multi-agent",
+    "simulation",
+    "agent-based-modeling",
+    "ai",
+    "generative-ai",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 packages = [{ include = "neva" }]
+
+[tool.poetry.urls]
+"Bug Tracker" = "https://github.com/davletovb/neva/issues"
+"Changelog" = "https://github.com/davletovb/neva/blob/main/CHANGELOG.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
@@ -23,6 +53,8 @@ transformers = { version = "^4.35.2", optional = true }
 mlflow = { version = "^2.9.1", optional = true }
 anthropic = { version = "^0.26.0", optional = true }
 "google-generativeai" = { version = "^0.3.2", optional = true }
+"faiss-cpu" = { version = "^1.7.4", optional = true }
+numpy = { version = "^1.26.4", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 black = "23.9.1"
@@ -42,6 +74,7 @@ tools = ["wikipedia", "deep-translator", "transformers"]
 mlops = ["mlflow"]
 providers = ["anthropic", "google-generativeai"]
 observability = ["opentelemetry-api", "opentelemetry-sdk"]
+memory = ["faiss-cpu", "numpy"]
 all = [
     "wikipedia",
     "deep-translator",
@@ -51,6 +84,8 @@ all = [
     "google-generativeai",
     "opentelemetry-api",
     "opentelemetry-sdk",
+    "faiss-cpu",
+    "numpy",
 ]
 
 [tool.black]

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,10 +1,22 @@
+# Optional dependencies, grouped by the pyproject extras they back.
+# Install only the bundles you need to keep the core install lightweight.
+
+# tools extra
 wikipedia==1.4.0
 deep-translator==1.11.4
 transformers==4.35.2
+
+# mlops extra
 mlflow==2.9.1
+
+# providers extra
 anthropic==0.26.0
 google-generativeai==0.3.2
+
+# memory extra (FAISS vector store)
 faiss-cpu==1.7.4
 numpy==1.26.4
+
+# observability extra
 opentelemetry-api==1.23.0
 opentelemetry-sdk==1.23.0


### PR DESCRIPTION
Prepare the project for distribution with packaging hygiene fixes:

- pyproject: add project URLs, keywords, and trove classifiers; declare a `memory` extra for the FAISS vector store (faiss-cpu + numpy).
- Add PEP 561 `neva/py.typed` so downstream projects consume the type hints.
- Add a Python `.gitignore` for build/coverage/cache/runtime artifacts.
- Fix a malformed `RUN apt-get` line continuation in the Dockerfile.
- Point the README "Last Commit" badge at the `main` branch.
- Flesh out CHANGELOG (Keep a Changelog format) and replace the placeholder Code of Conduct contact with a private GitHub reporting route.
- Group requirements-optional.txt by the extras it backs.